### PR TITLE
RDKB-60741: Extend wan link heal selfheal reboot for all reboot reasons.

### DIFF
--- a/source/scripts/init/service.d/service_crond.sh
+++ b/source/scripts/init/service.d/service_crond.sh
@@ -267,10 +267,6 @@ service_start ()
       echo "*/$interval * * * * /usr/ccsp/tad/remote_port_usage.sh" >> $CRONTAB_FILE
    fi
 
-	#This variable is to check RFC ETHWAN Mode Enabled/Disabled from syscfg DB
-	rfc_ethwan_status=""
-	rfc_ethwan_status=`syscfg get eth_wan_enabled`
-
 	#This variable is to check RFC WANLinkHeal Enabled/Disabled from syscfg DB
 	rfc_wanlinkheal_status=""
 	rfc_wanlinkheal_status=`syscfg get wanlinkheal`
@@ -279,7 +275,6 @@ service_start ()
 	#RFC ETHWAN should be false/null and WAN_TYPE should be DOCSIS
 	#RF WANLinkHeal should be true and BOX_TYPE should be plaftorm specfic
 	#In CISCOXB3 platform, does not have WAN_TYPE paramenter in /etc/device.properties file, So added MODEL_NUM Check along with WAN_TYPE.
-	if [ "$rfc_ethwan_status" = "false" ] || [ -z "$rfc_ethwan_status" ]; then
 		if [ "$WAN_TYPE" = "DOCSIS" ] || [ "$MODEL_NUM" = "DPC3941" ] || [ "$MODEL_NUM" = "DPC3941B" ] || [ "$MODEL_NUM" = "DPC3939B" ]; then
 			if [ "$rfc_wanlinkheal_status" = "true" ]; then
 				if [ "$BOX_TYPE" = "XB3" ] || [ "$BOX_TYPE" = "XB6" ] || [ "$BOX_TYPE" = "TCCBR" ]; then
@@ -294,9 +289,6 @@ service_start ()
 		else
 			echo_t "This Device WAN TYPE is not DOCSIS, Needed DOCSIS type Device for WANLinkHeal"
 		fi
-	else
-		echo_t "This Device should not enabled ETHWAN mode"
-	fi
 
    fi
  

--- a/source/scripts/init/service.d/waninfo.sh
+++ b/source/scripts/init/service.d/waninfo.sh
@@ -49,7 +49,7 @@ IsGWinWFO()
   wan_ifname=`sysevent get wan_ifname`
   wan_status=0
 
-  if [ "$cur_ifname" != "$wan_ifname" ]; then
+  if [ -n "$cur_ifname" ] && [ "$cur_ifname" != "$wan_ifname" ]; then
         wan_status=1
   fi
   echo "$wan_status" 


### PR DESCRIPTION
Reason for change: To implement WAN link heal selfheal for all types of
reboot rather limiting to Software upgrade.
Test Procedure: 1.simulate CMFailure, CMIPFailure, WANIPFailure, ConnectivityFailure.
2.In all the above cases, CPE should go for a reboot.
3.Reboots limit is 3 times a day.
Risks: None
Priority: P0
Signed-off-by: BalajiChowdary_Unnam@comcast.com

Change-Id: I773749cabbf0215503da9f89ecb70b603cef30be
(cherry picked from commit 0fc58b1ec5b5b68cf06c24cf66e6a4d9d2c7875c)