### PR TITLE
RDKCOM-5347: RDKBDEV-3109 : Verify 'syseventd' success status in Utopia duri

### DIFF
--- a/source/scripts/init/system/utopia_init.sh
+++ b/source/scripts/init/system/utopia_init.sh
@@ -468,8 +468,15 @@ echo $TOT_MSG_MAX > /proc/sys/fs/mqueue/msg_max
 echo_t "[utopia][init] Starting sysevent subsystem"
 #syseventd --threads 18
 syseventd
+sleep 1
+sysevent_pid="$(pidof syseventd)"
+sysevent_status="$(sysevent ping)"
+if [ "$sysevent_status" != "SUCCESS" ]; then
+   echo_t "[utopia][init] ERROR Syseventd subsystem is not started properly: ${sysevent_status}, pid: ${sysevent_pid}"
+else
+   echo_t "[utopia][init] Syseventd subsystem started with pid: ${sysevent_pid} successfully"
+fi
 
-sleep 1 
 echo_t "[utopia][init] Setting any unset system values to default"
 apply_system_defaults
 changeFilePermissions $SYSCFG_BKUP_FILE 400


### PR DESCRIPTION
Reason for change: During boot up, we will start 'syseventd' subsystem in utopia_init.sh script. But we are not checking its status whether it got started successfully or not. Therefore, condition is added to check the same when we start 'syseventd' subsystem. Risks: Low
Signed-off-by: Aiswarya Prasad <aprasad@maxlinear.com>
Test Procedure: None.
Priority: P1

Change-Id: Id7ee1d3df8430b6721c07dcf19698e2854673806 (cherry picked from commit ee8a39cdb276db9f1e007fe5d2bc76daef1c72f3)