### PR TITLE
RDKCOM-5360: RDKBNETWOR-73  LAN clients are not receiving an IPv4 address

### DIFF
--- a/source/service_dhcp/service_dhcp.c
+++ b/source/service_dhcp/service_dhcp.c
@@ -447,7 +447,6 @@ int service_dhcp_main(int argc, char *argv[])
 
     if (!strncmp(argv[1], "dhcp_server-restart", 19))
     {
-#if !defined (FEATURE_RDKB_DHCP_MANAGER)
         dhcp_server_stop();
         if (3 == argc)
         {   
@@ -457,11 +456,9 @@ int service_dhcp_main(int argc, char *argv[])
         {
             dhcp_server_start(NULL);
         }
-#endif
     }
 	else if (!strncmp(argv[1], "dhcp_server-start", 17))
 	{
-#if !defined (FEATURE_RDKB_DHCP_MANAGER)
 		if (3 == argc)
 		{	
 			dhcp_server_start(argv[2]);
@@ -470,17 +467,13 @@ int service_dhcp_main(int argc, char *argv[])
 		{
 			dhcp_server_start(NULL);
 		}
-#endif
 	}
         else if(!strncmp(argv[1],"dhcp_server-stop",16))
         {
-#if !defined (FEATURE_RDKB_DHCP_MANAGER)
              dhcp_server_stop();
-#endif
         }
         else if (!strncmp(argv[1], "lan-status", 10))
 	{
-#if !defined (FEATURE_RDKB_DHCP_MANAGER)
 		//If lan-status is called with lan_not_restart then 
 		//the same is used in further function calls
 		if (4 == argc)
@@ -491,7 +484,6 @@ int service_dhcp_main(int argc, char *argv[])
 		{
 			lan_status_change(NULL);
 		}
-#endif
 	}
 	else if (!strncmp(argv[1], "bring-lan", 9) || !strncmp(argv[1], "pnm-status", 10))
 	{
@@ -503,7 +495,7 @@ int service_dhcp_main(int argc, char *argv[])
       		UpdateDhcpConfChangeBasedOnEvent();
 		dhcp_server_start(NULL);
     	}
-      	#endif
+	#endif
 	else if (!strncmp(argv[1], "lan-restart", 11))
 	{
 		lan_restart();
@@ -537,13 +529,7 @@ int service_dhcp_main(int argc, char *argv[])
                                      buf, l_cL2Inst, sizeof(l_cL2Inst));
                         if (l_cL2Inst[0] != '\0')
                         {
-                                #if !defined (FEATURE_RDKB_DHCP_MANAGER)
                                 lan_status_change("lan_not_restart");
-                                #else
-                                //Setting an event to start dhcp server with brlan1 as code is moved to CcspDHCPMgr component
-                                //Further modifications will be taken care later
-                                sysevent_set(g_iSyseventfd, g_tSysevent_token, "dhcp_server-start", "lan_not_restart", 0);
-                                #endif
                         }
                 }
                 else
@@ -625,7 +611,6 @@ int service_dhcp_main(int argc, char *argv[])
             printf("Insufficient number of arguments for %s\n", argv[1]);
         }
     }   
-#if !defined (FEATURE_RDKB_DHCP_MANAGER) 
     else if(!strncmp(argv[1], "syslog-status", 13))
     {
         char syslog_status_buf[10]={0};
@@ -637,7 +622,6 @@ int service_dhcp_main(int argc, char *argv[])
             syslog_restart_request();
         }
     }
-#endif
     else if(!strncmp(argv[1], "ipv4-set_dyn_config", 19))
     {
         if (argc > 2)
@@ -678,12 +662,10 @@ int service_dhcp_main(int argc, char *argv[])
     {
         resync_all_instance();
     }
-#if !defined (FEATURE_RDKB_DHCP_MANAGER)
     else if(!strncmp(argv[1], "dhcp_server-resync", 18))
     {
         resync_to_nonvol(NULL);
     }
-#endif
     else if((!strncmp(argv[1], "multinet_1-status", 17)) ||  
             (!strncmp(argv[1], "multinet_2-status", 17)) ||  
             (!strncmp(argv[1], "multinet_3-status", 17)) ||

--- a/source/service_dhcp/service_dhcp_server.c
+++ b/source/service_dhcp/service_dhcp_server.c
@@ -341,7 +341,6 @@ int dnsmasq_server_start()
     return executeCmd(l_cSystemCmd);
 }
 
-#if !defined (FEATURE_RDKB_DHCP_MANAGER)
 void dhcp_server_stop()
 {
         char l_cDhcp_Status[16] = {0}, l_cSystemCmd[255] = {0};
@@ -407,7 +406,6 @@ void dhcp_server_stop()
         fprintf(g_fArmConsoleLog, "dns-server didnt start\n");
 	}
 }
-#endif
 
 BOOL IsDhcpConfHasInterface(void)
 {
@@ -595,7 +593,6 @@ int syslog_restart_request()
     return 0;
 }
 
-#if !defined (FEATURE_RDKB_DHCP_MANAGER)
 int dhcp_server_start (char *input)
 {
         fprintf(g_fArmConsoleLog, "\nInside  %s function with arg %s\n", __FUNCTION__,input);
@@ -991,7 +988,6 @@ int dhcp_server_start (char *input)
         fprintf(g_fArmConsoleLog,"\n %s function ENDS\n",__FUNCTION__);
 	return 0;
 }
-#endif
 
 void resync_to_nonvol(char *RemPools)
 {
@@ -1425,7 +1421,6 @@ int service_dhcp_init()
     return SUCCESS;
 }
 
-#if !defined (FEATURE_RDKB_DHCP_MANAGER)
 void lan_status_change(char *input)
 {
 
@@ -1489,4 +1484,3 @@ void lan_status_change(char *input)
 		}
 	}
 }
-#endif


### PR DESCRIPTION
Reason for change: LAN clients are not receiving an IPv4 address. DHCPManager flag enabled in utopia Test Procedure: Refer to JIRA
Risks: Low
Signed-off-by:Aadhithan_PE@comcast.com

Change-Id: I09d8c6d08a896650211e6dc6bcc3a91923933b70 (cherry picked from commit 5c2b9de01ce43ee3ea8aff81803ffb83b441a246) (cherry picked from commit 21583254ae18ddbeeb7203882bc8c43750ce430a)