### PR TITLE
RDKCOM-5340: RDKBDEV-3156: drop obsolete defaults for FW_LOG_FILE_PATH

### DIFF
--- a/source/scripts/init/defaults/system_defaults_arm
+++ b/source/scripts/init/defaults/system_defaults_arm
@@ -947,8 +947,6 @@ $Adv_AdvSecCujoTelemetryRFCEnable=0
 $Adv_RaptrRFCEnable=1
 
 #Firewall log settings
-$FW_LOG_FILE_PATH=/nvram/log/firewall
-@FW_LOG_FILE_PATH_V2=/nvram/log/firewall
 $$FW_LOG_COMPRESSED_FILE_SIZE=10
 
 #SYSTEM log settings

--- a/source/scripts/init/defaults/system_defaults_bci
+++ b/source/scripts/init/defaults/system_defaults_bci
@@ -927,8 +927,6 @@ $rlog_host=10.1.10.120
 $rlog_port=514
 
 #Firewall log settings
-$FW_LOG_FILE_PATH=/nvram/log/firewall
-@FW_LOG_FILE_PATH_V2=/nvram/log/firewall
 $$FW_LOG_COMPRESSED_FILE_SIZE=10
 
 #SYSTEM log settings

--- a/source/scripts/init/defaults/system_defaults_xd4
+++ b/source/scripts/init/defaults/system_defaults_xd4
@@ -936,8 +936,6 @@ $Adv_AdvSecCujoTelemetryRFCEnable=0
 $Adv_RaptrRFCEnable=1
 
 #Firewall log settings
-$FW_LOG_FILE_PATH=/nvram/log/firewall
-@FW_LOG_FILE_PATH_V2=/nvram/log/firewall
 $$FW_LOG_COMPRESSED_FILE_SIZE=10
 
 #SYSTEM log settings


### PR DESCRIPTION
Reason for change:
system_defaults: drop obsolete defaults for FW_LOG_FILE_PATH / FW_LOG_FILE_PATH_V2 Test Procedure: Sanity.
Risks: None.
Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
Priority: P1

Change-Id: I83ec3d1485226588a0e82939bafe6f21ba3a4ce7 (cherry picked from commit fdef2d7c80301dfed6d21ee869d7af44565fa144)