### PR TITLE
RDKCOM-5307: RDKBDEV-3161: syscfg: add syscfg_getall2() + use it...

### DIFF
--- a/source/include/syscfg/syscfg.h
+++ b/source/include/syscfg/syscfg.h
@@ -131,6 +131,12 @@ int syscfg_get(const char *ns, const char *name, char *out_value, int outbufsz);
 int syscfg_getall(char *buf, int bufsz, int *outsz);
 
 /*
+ * Like syscfg_getall(), but returns pairs of entries separated by
+ * newlines instead nul characters.
+ */
+int syscfg_getall2(char *buf, size_t bufsz, size_t *outsz);
+
+/*
  * Procedure     : syscfg_set
  * Purpose       : Adds an entry to syscfg
  * Parameters    :   

--- a/source/syscfg/cmd/syscfgcmd.c
+++ b/source/syscfg/cmd/syscfgcmd.c
@@ -165,27 +165,15 @@ int main (int argc, char **argv)
     }
     else if (strcmp(cmd[0], "show") == 0)
     {
-        int len, sz;
+        size_t sz;
         long int used_sz = 0, max_sz = 0;
-        char *buf;
+        char buf[SYSCFG_SZ];
 
-        buf = malloc(SYSCFG_SZ);
-
-        if (buf) {
-            if (syscfg_getall(buf, SYSCFG_SZ, &sz) == 0) {
-                char *p = buf;
-                while (sz > 0) {
-                    len = printf("%s", p);
-                    printf("\n");
-                    p = p + len + 1;
-                    sz -= len + 1;
-                }
-            }
-            else {
-                printf("No entries\n");
-            }
-
-            free(buf);
+        if (syscfg_getall2(buf, sizeof(buf), &sz) == 0) {
+            fwrite(buf, 1, sz, stdout);
+        }
+        else {
+            printf("No entries\n");
         }
 
         syscfg_getsz(&used_sz, &max_sz);

--- a/source/syscfg/lib/syscfg.h
+++ b/source/syscfg/lib/syscfg.h
@@ -135,6 +135,12 @@ int syscfg_get(const char *ns, const char *name, char *out_value, int outbufsz);
 int syscfg_getall(char *buf, int bufsz, int *outsz);
 
 /*
+ * Like syscfg_getall(), but returns pairs of entries separated by
+ * newlines instead nul characters.
+ */
+int syscfg_getall2(char *buf, size_t bufsz, size_t *outsz);
+
+/*
  * Procedure     : syscfg_set
  * Purpose       : Adds an entry to syscfg
  * Parameters    :   

--- a/source/syscfg/lib/syscfg_lib.h
+++ b/source/syscfg/lib/syscfg_lib.h
@@ -197,6 +197,7 @@ static int _syscfg_set (const char *ns, const char *name, const char *value, int
 static int _syscfg_unset (const char *ns, const char *name, int nolock);
 static char* _syscfg_get (const char *ns, const char *name);
 static int _syscfg_getall (char *buf, int bufsz);
+static size_t _syscfg_getall2 (char *buf, size_t bufsz, int nolock);
 static void _syscfg_destroy ();
 
 static inline int read_lock (syscfg_shm_ctx *ctx);


### PR DESCRIPTION
Reason for change:
syscfg: add syscfg_getall2() + use it to optimise syscfg show Add new syscfg API to fetch all syscfg values in a format which can be used directly by syscfg show.
Test Proccedure: Sanity.
Risks: None.
Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
Test Procedure: None.
Priority: P1

Change-Id: If1bc7d19a5ec73426b0c23b5c84c9b07071dada4 (cherry picked from commit e608c67d13d067b73c8cf19320a133ec15ef5943)