### PR TITLE
RDKCOM-5356: OneWifi and WFO features should not force platform to use OVS

### DIFF
--- a/source/scripts/init/c_registration/02_multinet.c
+++ b/source/scripts/init/c_registration/02_multinet.c
@@ -286,8 +286,7 @@ void srv_register(void) {
 
       }
 
-      if( (0 == access( ONEWIFI_ENABLED, F_OK )) || (0 == access( OPENVSWITCH_LOADED, F_OK ))
-                                                 || (0 == access( WFO_ENABLED, F_OK )) )
+      if( 0 == access( OPENVSWITCH_LOADED, F_OK ) )
       {
           ovsEnable = 1;
       }

--- a/source/service_wan/service_wan.c
+++ b/source/service_wan/service_wan.c
@@ -759,14 +759,12 @@ STATIC int wan_start(struct serv_wan *sw)
         {
             if( 0 == syscfg_get( NULL, "mesh_ovs_enable", ovs_enable, sizeof( ovs_enable ) ) )
             {
-                if ((strcmp(ovs_enable,"true") == 0) || (0 == access(ONEWIFI_ENABLED, F_OK)) ||
-                   (access(WFO_ENABLED, F_OK) == 0 ) || (0 == access(OPENVSWITCH_LOADED, F_OK)))
+                if ((strcmp(ovs_enable,"true") == 0) || (0 == access(OPENVSWITCH_LOADED, F_OK)))
                 {
                     v_secure_system("/usr/bin/bridgeUtils add-port brlan0 llan0 &");
                 }
             }
-            else if ((0 == access(ONEWIFI_ENABLED, F_OK)) || (0 == access(OPENVSWITCH_LOADED, F_OK))
-                                                          || (access(WFO_ENABLED, F_OK) == 0 ) )
+            else if (0 == access(OPENVSWITCH_LOADED, F_OK))
             {
                 v_secure_system("/usr/bin/bridgeUtils add-port brlan0 llan0 &");
             }


### PR DESCRIPTION
Reason for change: Usage of OneWifi and WFO features forces platform
 to use OVS
Test Procedure: Check the build
Risks: None
Signed-off-by: Danil Chestyunin <dchestyunin@maxlinear.com>
Priority: P1

Change-Id: Ibe823ed7056e9f3e2e2bd5cbee745ffb6fc21b26 (cherry picked from commit 9520e5784d131b2622d790941e7d920d3a554fab)