### PR TITLE
Revert "Revert "[XER10-1237](https://ccp.sys.comcast.net/browse/XER10-1237) : syscfg.db file not present in /opt/secure/data""

### DIFF
--- a/source/scripts/init/system/utopia_init.sh
+++ b/source/scripts/init/system/utopia_init.sh
@@ -122,7 +122,7 @@ MWO_PATH="/nvram/mwo"
 CHANNEL_KEEPOUT_PATH="/nvram/mesh"
 
 ENCRYPT_SYSCFG=false
-if [ "$MODEL_NUM" = "VTER11QEL" ]; then
+if [ "$MODEL_NUM" = "VTER11QEL" ] || [ "$MODEL_NUM" = "SCER11BEL" ]; then
    ENCRYPT_SYSCFG=true
 fi
 


### PR DESCRIPTION
Revert "Revert "[XER10-1237](https://ccp.sys.comcast.net/browse/XER10-1237) : syscfg.db file not present in /opt/secure/data""

Changes missing in stable2 possible suspect - [XER10-1957](https://ccp.sys.comcast.net/browse/XER10-1957)

This reverts commit 119a1595dbe41868b2f7c63c693e7111f2b47e1a.

Change-Id: I07adf7c5b90e0c89abb659d586d5766cba776621