### PR TITLE
Revert "RDKCOM-5356 to fix CBR2-2206: OneWifi and WFO features should not force platform to use OVS"

### DIFF
--- a/source/scripts/init/c_registration/02_multinet.c
+++ b/source/scripts/init/c_registration/02_multinet.c
@@ -286,7 +286,8 @@ void srv_register(void) {
 
       }
 
-      if( 0 == access( OPENVSWITCH_LOADED, F_OK ) )
+      if( (0 == access( ONEWIFI_ENABLED, F_OK )) || (0 == access( OPENVSWITCH_LOADED, F_OK ))
+                                                 || (0 == access( WFO_ENABLED, F_OK )) )
       {
           ovsEnable = 1;
       }

--- a/source/service_wan/service_wan.c
+++ b/source/service_wan/service_wan.c
@@ -759,12 +759,14 @@ STATIC int wan_start(struct serv_wan *sw)
         {
             if( 0 == syscfg_get( NULL, "mesh_ovs_enable", ovs_enable, sizeof( ovs_enable ) ) )
             {
-                if ((strcmp(ovs_enable,"true") == 0) || (0 == access(OPENVSWITCH_LOADED, F_OK)))
+                if ((strcmp(ovs_enable,"true") == 0) || (0 == access(ONEWIFI_ENABLED, F_OK)) ||
+                   (access(WFO_ENABLED, F_OK) == 0 ) || (0 == access(OPENVSWITCH_LOADED, F_OK)))
                 {
                     v_secure_system("/usr/bin/bridgeUtils add-port brlan0 llan0 &");
                 }
             }
-            else if (0 == access(OPENVSWITCH_LOADED, F_OK))
+            else if ((0 == access(ONEWIFI_ENABLED, F_OK)) || (0 == access(OPENVSWITCH_LOADED, F_OK))
+                                                          || (access(WFO_ENABLED, F_OK) == 0 ) )
             {
                 v_secure_system("/usr/bin/bridgeUtils add-port brlan0 llan0 &");
             }


### PR DESCRIPTION
Reason for revert: To see if revert fixes CBR2-2206

This reverts commit 122e9c3a75e7dce8a88630f8a504f9e66f2db07d.

Change-Id: If2eba3fb5ffe0ccbb4a266f64ebde529ca34e068