### PR TITLE
RDKB-59896:Enable network isolation to deny SSH from Dev Jump VM to Prod VM using SHORTS

### DIFF
--- a/source/scripts/init/defaults/system_defaults_arm
+++ b/source/scripts/init/defaults/system_defaults_arm
@@ -1449,7 +1449,7 @@ $LatencyMeasure_IPv6Enable=false
 $LatencyMeasure_TCPReportInterval=15
 $LatencyMeasure_PercentileCalc_Enable=false
 #DeviceType default value
-$DeviceType=TEST
+$DeviceType=PROD
 
 #Default value of 3600 seconds to store time in syscfg
 $timeoffset_sleep_time=3600

--- a/source/scripts/init/defaults/system_defaults_bci
+++ b/source/scripts/init/defaults/system_defaults_bci
@@ -1310,7 +1310,7 @@ $DscpSleepInterval_2=0
 $SWDLDirectEnable=false
 
 #DeviceType default value
-$DeviceType=TEST
+$DeviceType=PROD
 
 #TrackRemotePortUsage default value
 $TrackRemotePortUsage=NULL


### PR DESCRIPTION
Reason for change: Set default DeviceType RFC type to PROD
Test Procedure: Build and verify
Risks: None
Priority:<P1>