### PR TITLE
RDKB-61372: Handling recovery cases of Unknown/Invalid syscfg PartnerID

### DIFF
--- a/source/scripts/init/src/apply_system_defaults/apply_system_defaults.c
+++ b/source/scripts/init/src/apply_system_defaults/apply_system_defaults.c
@@ -80,6 +80,8 @@
 #define STATIC
 #endif
 
+#define PARTNER_ID_MAX_RETRY	5
+
 static int   syscfg_dirty;
 
 #define DEFAULT_FILE "/etc/utopia/system_defaults"
@@ -689,7 +691,7 @@ static int GetDevicePropertiesEntry (char *pOutput, int size, char *sDevicePropC
 
 static int getFactoryPartnerId (char *pValue)
 {
-#if defined (_XB6_PRODUCT_REQ_) || defined(_HUB4_PRODUCT_REQ_) || defined(_SR300_PRODUCT_REQ_) || defined(_WNXL11BWL_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)
+#if defined (_XB6_PRODUCT_REQ_) || defined(_HUB4_PRODUCT_REQ_) || defined(_SR300_PRODUCT_REQ_) || defined(_WNXL11BWL_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_) || defined (_RDKB_GLOBAL_PRODUCT_REQ_)
 	if(0 == platform_hal_getFactoryPartnerId(pValue))
 	{
 		APPLY_PRINT("%s:%d - %s\n",__FUNCTION__, __LINE__,pValue);
@@ -745,6 +747,111 @@ static int validatePartnerId (char *PartnerID)
    }
    return result;
 }
+
+#if defined (_RDKB_GLOBAL_PRODUCT_REQ_)
+static int PartnerId_FetchWithRetry(char *PartnerID ) {
+    int retries = 0;
+    char buf[PARTNER_ID_LEN] = {0};
+
+    for(retries = 0; retries < PARTNER_ID_MAX_RETRY; retries++) {
+        memset(PartnerID, 0, PARTNER_ID_LEN);
+
+        if((0 == getFactoryPartnerId(PartnerID)) && (PartnerID[0] != '\0') &&
+            validatePartnerId(PartnerID) && (0 != strcasecmp (PartnerID, "Unknown"))) {
+            return 0;
+        }
+        else {
+            memset(buf, 0, sizeof(buf));
+
+            if ( 0 == GetDevicePropertiesEntry(buf, sizeof(buf), "PARTNER_ID")) {
+                if(buf[0] !=  '\0') {
+                    strncpy(PartnerID, buf, strlen(buf));
+                    PartnerID[strlen(buf)] = '\0';
+
+                    if(validatePartnerId(PartnerID) && (0 != strcasecmp(PartnerID, "Unknown") )) {
+                        return 0;
+                    }
+                }
+            }
+        }
+
+        if((retries + 1) < PARTNER_ID_MAX_RETRY) {
+            APPLY_PRINT("%s - Still obtaining invalid PartnerID value from various sources so Retrying, Iteration: <%d>\n", __FUNCTION__, retries);
+            sleep(2);
+        }
+    }
+
+    return 1;
+}
+
+int WritePartnerIDToFile(char* PartnerID) {
+    FILE *fp = NULL;
+
+    fp = fopen(PARTNERID_FILE, "w");
+    if(NULL == fp) {
+        APPLY_PRINT("%s - Failed to open file %s\n", __FUNCTION__, PARTNERID_FILE);
+        return 1;
+    }
+
+    if( (NULL != PartnerID) && (strlen(PartnerID) > 0) ) {
+        fwrite(PartnerID, strlen(PartnerID), 1, fp);
+        APPLY_PRINT("%s - PartnerID %s written to file %s\n", __FUNCTION__, PartnerID, PARTNERID_FILE);
+    }
+    else {
+        APPLY_PRINT("%s - PartnerID is NULL\n", __FUNCTION__);
+        if(fp) {
+            fclose(fp);
+        }
+
+        return 1;
+    }
+
+    if(fp) {
+        fclose(fp);
+    }
+
+    return 0;
+}
+
+void CheckAndHandleInvalidPartnerIDRecoveryProcess(char *PartnerID) {
+    if( '\0' == PartnerID[0] || (0 == validatePartnerId(PartnerID)) || (0 == strcasecmp (PartnerID, "Unknown")) ) {
+        memset(PartnerID, 0, sizeof(PartnerID));
+
+        APPLY_PRINT("%s - Current PartnerID value is Unknown/Invalid, So retrying to obtain valid PartnerID values. \n", __FUNCTION__);
+        t2_event_d("SYS_ERROR_INVALID_PARTNER_ID_DETECTED", 1);
+        if( 0 == PartnerId_FetchWithRetry(PartnerID) ) {
+            APPLY_PRINT("%s - INVALID_PARTNER_ID_RECOVERY_SUCCESS - Obtained Valid PartnerID is %s\n", __FUNCTION__, PartnerID );
+            t2_event_d("SYS_INVALID_PARTNER_ID_RECOVERY_SUCCESS", 1);
+
+            if (syscfg_set_commit(NULL, "PartnerID", PartnerID) != 0) {
+                APPLY_PRINT("%s - PartnerID syscfg_set failed\n", __FUNCTION__);
+            }
+
+            WritePartnerIDToFile(PartnerID);
+
+            if (syscfg_set_commit(NULL, "factory_reset", "y") != 0) {
+                APPLY_PRINT("%s - syscfg_set failed\n", __FUNCTION__);
+            }
+
+            creat("/nvram/.Invalid_PartnerID", 0644);
+            v_secure_system("/rdklogger/backupLogs.sh");
+
+        }
+        else {
+            if (syscfg_set_commit(NULL, "PartnerID", "Unknown") != 0) {
+                APPLY_PRINT("%s - syscfg_set failed\n", __FUNCTION__);
+            }
+
+            APPLY_PRINT("%s - INVALID_PARTNER_ID_RECOVERY_FAILURE - PartnerID is %s\n", __FUNCTION__, PartnerID );
+            t2_event_d("SYS_ERROR_INVALID_PARTNER_ID_RECOVERY_FAILURE", 1);
+        }
+    }
+    else {
+        APPLY_PRINT("%s - Current PartnerID : %s value is Valid \n", __FUNCTION__, PartnerID );
+    }
+}
+
+#endif // (_RDKB_GLOBAL_PRODUCT_REQ_)
 
 static int get_PartnerID (char *PartnerID)
 {
@@ -3138,7 +3245,7 @@ if ( paramObjVal != NULL )
    }
     return 0;
 }
-#if defined (_XB6_PRODUCT_REQ_) || defined(_HUB4_PRODUCT_REQ_)
+#if defined (_XB6_PRODUCT_REQ_) || defined(_HUB4_PRODUCT_REQ_) || defined (_RDKB_GLOBAL_PRODUCT_REQ_)
 static void getPartnerIdWithRetry(char* buf, char* PartnerID)
 {
         int i;
@@ -3292,6 +3399,10 @@ static void getPartnerIdWithRetry(char* buf, char* PartnerID)
     APPLY_PRINT("%s - PartnerID :%s. Calling get_PartnerID() to get a valid PartnerID that was received from XConf \n", __FUNCTION__, PartnerID );
     get_PartnerID ( PartnerID );
   }
+
+#if defined (_RDKB_GLOBAL_PRODUCT_REQ_)
+   CheckAndHandleInvalidPartnerIDRecoveryProcess(PartnerID);
+#endif // (_RDKB_GLOBAL_PRODUCT_REQ_)
 
    APPLY_PRINT("%s - PartnerID :%s\n", __FUNCTION__, PartnerID );
 

--- a/source/scripts/init/src/apply_system_defaults/apply_system_defaults_syscfg.c
+++ b/source/scripts/init/src/apply_system_defaults/apply_system_defaults_syscfg.c
@@ -228,6 +228,10 @@ int main( int argc, char **argv )
         get_PartnerID ( PartnerID );
     }
 
+#if defined (_RDKB_GLOBAL_PRODUCT_REQ_)
+    CheckAndHandleInvalidPartnerIDRecoveryProcess(PartnerID);
+#endif // (_RDKB_GLOBAL_PRODUCT_REQ_)
+
     APPLY_PRINT("%s - PartnerID :%s\n", __FUNCTION__, PartnerID );
 
     ptr_etc_json = json_file_parse( PARTNERS_INFO_FILE_ETC );

--- a/source/scripts/init/src/apply_system_defaults_helper.c
+++ b/source/scripts/init/src/apply_system_defaults_helper.c
@@ -733,9 +733,9 @@ static int GetDevicePropertiesEntry (char *pOutput, int size, char *sDevicePropC
     return ret;
 }
 
-static int getFactoryPartnerId (char *pValue)
+int getFactoryPartnerId (char *pValue)
 {
-#if defined (_XB6_PRODUCT_REQ_) || defined(_HUB4_PRODUCT_REQ_) || defined(_SR300_PRODUCT_REQ_) || defined(_WNXL11BWL_PRODUCT_REQ_)
+#if defined (_XB6_PRODUCT_REQ_) || defined(_HUB4_PRODUCT_REQ_) || defined(_SR300_PRODUCT_REQ_) || defined(_WNXL11BWL_PRODUCT_REQ_) || defined (_RDKB_GLOBAL_PRODUCT_REQ_)
 	if(0 == platform_hal_getFactoryPartnerId(pValue))
 	{
 		APPLY_PRINT("%s:%d - %s\n",__FUNCTION__, __LINE__,pValue);
@@ -1015,6 +1015,111 @@ static void ValidateAndUpdatePartnerVersionParam (cJSON *root_etc_json, cJSON *r
         }
     }
 }
+
+#if defined (_RDKB_GLOBAL_PRODUCT_REQ_)
+int PartnerId_FetchWithRetry(char *PartnerID ) {
+    int retries = 0;
+    char buf[PARTNER_ID_LEN] = {0};
+
+    for(retries = 0; retries < PARTNER_ID_MAX_RETRY; retries++) {
+        memset(PartnerID, 0, PARTNER_ID_LEN);
+
+        if((0 == getFactoryPartnerId(PartnerID)) && (PartnerID[0] != '\0') &&
+            validatePartnerId(PartnerID) && (0 != strcasecmp (PartnerID, "Unknown"))) {
+            return 0;
+        }
+        else {
+            memset(buf, 0, sizeof(buf));
+
+            if ( 0 == GetDevicePropertiesEntry(buf, sizeof(buf), "PARTNER_ID")) {
+                if(buf[0] !=  '\0') {
+                    strncpy(PartnerID, buf, strlen(buf));
+                    PartnerID[strlen(buf)] = '\0';
+
+                    if(validatePartnerId(PartnerID) && (0 != strcasecmp(PartnerID, "Unknown") )) {
+                        return 0;
+                    }
+                }
+            }
+        }
+
+        if((retries + 1) < PARTNER_ID_MAX_RETRY) {
+            APPLY_PRINT("%s - Still obtaining invalid PartnerID value from various sources so Retrying, Iteration: <%d>\n", __FUNCTION__, retries);
+            sleep(2);
+        }
+    }
+
+    return 1;
+}
+
+int WritePartnerIDToFile(char* PartnerID) {
+    FILE *fp = NULL;
+
+    fp = fopen(PARTNERID_FILE, "w");
+    if(NULL == fp) {
+        APPLY_PRINT("%s - Failed to open file %s\n", __FUNCTION__, PARTNERID_FILE);
+        return 1;
+    }
+
+    if( (NULL != PartnerID) && (strlen(PartnerID) > 0) ) {
+        fwrite(PartnerID, strlen(PartnerID), 1, fp);
+        APPLY_PRINT("%s - PartnerID %s written to file %s\n", __FUNCTION__, PartnerID, PARTNERID_FILE);
+    }
+    else {
+        APPLY_PRINT("%s - PartnerID is NULL\n", __FUNCTION__);
+        if(fp) {
+            fclose(fp);
+        }
+
+        return 1;
+    }
+
+    if(fp) {
+        fclose(fp);
+    }
+
+    return 0;
+}
+
+void CheckAndHandleInvalidPartnerIDRecoveryProcess(char *PartnerID) {
+    if( '\0' == PartnerID[0] || (0 == validatePartnerId(PartnerID)) || (0 == strcasecmp (PartnerID, "Unknown")) ) {
+        memset(PartnerID, 0, sizeof(PartnerID));
+
+        APPLY_PRINT("%s - Current PartnerID value is Unknown/Invalid, So retrying to obtain valid PartnerID values. \n", __FUNCTION__);
+        t2_event_d("SYS_ERROR_INVALID_PARTNER_ID_DETECTED", 1);
+        if( 0 == PartnerId_FetchWithRetry(PartnerID) ) {
+            APPLY_PRINT("%s - INVALID_PARTNER_ID_RECOVERY_SUCCESS - Obtained Valid PartnerID is %s\n", __FUNCTION__, PartnerID );
+            t2_event_d("SYS_INVALID_PARTNER_ID_RECOVERY_SUCCESS", 1);
+
+            if (syscfg_set_commit(NULL, "PartnerID", PartnerID) != 0) {
+                APPLY_PRINT("%s - PartnerID syscfg_set failed\n", __FUNCTION__);
+            }
+
+            WritePartnerIDToFile(PartnerID);
+
+            if (syscfg_set_commit(NULL, "factory_reset", "y") != 0) {
+                APPLY_PRINT("%s - syscfg_set failed\n", __FUNCTION__);
+            }
+
+            creat("/nvram/.Invalid_PartnerID", 0644);
+            v_secure_system("/rdklogger/backupLogs.sh");
+
+        }
+        else {
+            if (syscfg_set_commit(NULL, "PartnerID", "Unknown") != 0) {
+                APPLY_PRINT("%s - syscfg_set failed\n", __FUNCTION__);
+            }
+
+            APPLY_PRINT("%s - INVALID_PARTNER_ID_RECOVERY_FAILURE - PartnerID is %s\n", __FUNCTION__, PartnerID );
+            t2_event_d("SYS_ERROR_INVALID_PARTNER_ID_RECOVERY_FAILURE", 1);
+        }
+    }
+    else {
+        APPLY_PRINT("%s - Current PartnerID : %s value is Valid \n", __FUNCTION__, PartnerID );
+    }
+}
+
+#endif // (_RDKB_GLOBAL_PRODUCT_REQ_)
 
 static char *getBuildTime (void)
 {

--- a/source/scripts/init/src/apply_system_defaults_helper.h
+++ b/source/scripts/init/src/apply_system_defaults_helper.h
@@ -27,7 +27,15 @@
 
 #define APPLY_DEFAULTS_FACTORY_RESET  "/tmp/.apply_defaults_factory_reset"
 
+#if defined (_RDKB_GLOBAL_PRODUCT_REQ_)
+#define PARTNER_ID_MAX_RETRY    5
+int PartnerId_FetchWithRetry(char *PartnerID );
+int WritePartnerIDToFile(char* PartnerID);
+void CheckAndHandleInvalidPartnerIDRecoveryProcess(char *PartnerID);
+#endif // (_RDKB_GLOBAL_PRODUCT_REQ_)
+
 int get_PartnerID( char *PartnerID);
+int getFactoryPartnerId (char *pValue);
 int parse_command_line(int argc, char **argv);
 int set_defaults(void);
 int set_syscfg_partner_values (char *pValue, char *param);

--- a/source/scripts/init/src/apply_system_defaults_psm/apply_system_defaults_psm.c
+++ b/source/scripts/init/src/apply_system_defaults_psm/apply_system_defaults_psm.c
@@ -221,6 +221,10 @@ int main( int argc, char **argv )
         get_PartnerID ( PartnerID );
     }
 
+#if defined (_RDKB_GLOBAL_PRODUCT_REQ_)
+    CheckAndHandleInvalidPartnerIDRecoveryProcess(PartnerID);
+#endif // (_RDKB_GLOBAL_PRODUCT_REQ_)
+
     APPLY_PRINT("%s - PartnerID :%s\n", __FUNCTION__, PartnerID );
 
     ptr_etc_json = json_file_parse( PARTNERS_INFO_FILE_ETC );

--- a/source/scripts/init/system/utopia_init.sh
+++ b/source/scripts/init/system/utopia_init.sh
@@ -655,6 +655,11 @@ if [ "$FACTORY_RESET_REASON" = "true" ]; then
        syscfg set X_RDKCENTRAL-COM_LastRebootReason "FirmwareDownloadAndFactoryReset"
        syscfg set X_RDKCENTRAL-COM_LastRebootCounter "1"
        rm -f /nvram/.image_upgrade_and_FR_done
+   elif [ -f "/nvram/.Invalid_PartnerID" ]; then
+       echo "[utopia][init] Detected last reboot reason as Reboot-DueTo-InvalidPartnerID"
+       syscfg set X_RDKCENTRAL-COM_LastRebootReason "Reboot-DueTo-InvalidPartnerID"
+       syscfg set X_RDKCENTRAL-COM_LastRebootCounter "1"
+       rm -f /nvram/.Invalid_PartnerID
    else
        echo_t "[utopia][init] Detected last reboot reason as factory-reset"
        if [ -e "/usr/bin/onboarding_log" ]; then

--- a/source/scripts/init/system/utopia_init_hub4.sh
+++ b/source/scripts/init/system/utopia_init_hub4.sh
@@ -542,10 +542,17 @@ echo "[utopia][init] Detected last reboot reason from driver as $LastRebootReaso
 echo "" > /proc/skyrbd
 
 if [ "$FACTORY_RESET_REASON" = "true" ]; then
-   echo "[utopia][init] Detected last reboot reason as factory-reset"
+   if [ -f "/nvram/.Invalid_PartnerID" ]; then
+      echo "[utopia][init] Detected last reboot reason as Reboot-DueTo-InvalidPartnerID"
+      syscfg set X_RDKCENTRAL-COM_LastRebootReason "Reboot-DueTo-InvalidPartnerID"
+      syscfg set X_RDKCENTRAL-COM_LastRebootCounter "1"
+      rm -f /nvram/.Invalid_PartnerID
+   else
+      echo "[utopia][init] Detected last reboot reason as factory-reset"
 
-   syscfg set X_RDKCENTRAL-COM_LastRebootReason "factory-reset"
-   syscfg set X_RDKCENTRAL-COM_LastRebootCounter "1"
+      syscfg set X_RDKCENTRAL-COM_LastRebootReason "factory-reset"
+      syscfg set X_RDKCENTRAL-COM_LastRebootCounter "1"
+   fi
 else
 #Check last reboot reasons
 case "$LastRebootReason" in

--- a/source/scripts/init/system/utopia_init_xb6.sh
+++ b/source/scripts/init/system/utopia_init_xb6.sh
@@ -791,6 +791,11 @@ if [ "$FACTORY_RESET_REASON" = "true" ]; then
        syscfg set X_RDKCENTRAL-COM_LastRebootReason "FirmwareDownloadAndFactoryReset"
        syscfg set X_RDKCENTRAL-COM_LastRebootCounter "1"
        rm -f /nvram/.image_upgrade_and_FR_done
+   elif [ -f "/nvram/.Invalid_PartnerID" ]; then
+       echo "[utopia][init] Detected last reboot reason as Reboot-DueTo-InvalidPartnerID"
+       syscfg set X_RDKCENTRAL-COM_LastRebootReason "Reboot-DueTo-InvalidPartnerID"
+       syscfg set X_RDKCENTRAL-COM_LastRebootCounter "1"
+       rm -f /nvram/.Invalid_PartnerID
    else
        echo "[utopia][init] Detected last reboot reason as factory-reset"
        if [ -e "/usr/bin/onboarding_log" ]; then


### PR DESCRIPTION
Reason for change: Add retry mechanism for PartnerID Unknown

Test Procedure:
1. Set PartnerID via TR181 DMs 
    a. Set the DM Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId with one of following values : "Unknown", "known", "sky-", "" 
    b. Set the DM dmcli eRT setv Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.RDKB_Control.ActivatePartnerId bool true 
    c. CPE goes for reboot and after reboot, Check if the PartnerID recovers with respective PartnerID configurations applied 
    d. After Recovery Reboot Reason should be Reboot-DueTo-InvalidPartnerID

2. Set PartnerID DB param via syscfg 
    a. set PartnerID with following values :  "Unknown", "known", "sky-", "" 
    b. syscfg commit 
    c. Reboot CPE and Check if the PartnerID recovers with respective PartnerID configurations applied 
    d. After Recovery Reboot Reason should be Reboot-DueTo-InvalidPartnerID

3. Upgrade scenario 
   a. Flash image without the fix, check Partner ID - sky-uk 
   b. Set Partner ID to "Unknown" using Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId 
   c. Activate PartnerID using Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.RDKB_Control.ActivatePartnerId 
   d. CPE goes for reboot and after reboot, check the DMs if the partner_defaults.json loaded for Unknown in the image without the fix. 
   e. Flash the image with the fix and check if the partner ID is recovered and valid config is loaded 
   f. After Recovery Reboot Reason should be Reboot-DueTo-InvalidPartnerID

4. Retry failure: If recovery fails after retry mechanism, then the PartnerID must be set to Unknown

Priority: P1

Risks: Low

Signed-off-by: Yashwanth Kumar H M <yashwanthkumar.hm@sky.uk>