### PR TITLE
TCXB8-3706 : SYS_SH_Syseventd_restart marker

### DIFF
--- a/source/scripts/init/service.d/pmon.sh
+++ b/source/scripts/init/service.d/pmon.sh
@@ -93,8 +93,8 @@ do_check_process() {
 
 	LOCAL_CONF_FILE=/tmp/pmon.conf$$
 
-	# Add static pmon entries
-	echo "syseventd	/var/run/syseventd.pid /etc/utopia/service.d/syseventd_restart.sh" > $LOCAL_CONF_FILE
+	# Add static pmon entries - commented-out below line - selfheal takes care of it.
+	# echo "syseventd	/var/run/syseventd.pid /etc/utopia/service.d/syseventd_restart.sh" > $LOCAL_CONF_FILE
 
 	# Add dynamic pmon entries stashed in sysevent
 	# by various modules

--- a/source/sysevent/server/syseventd_main.c
+++ b/source/sysevent/server/syseventd_main.c
@@ -1388,6 +1388,8 @@ int main (int argc, char **argv)
       clilen = sizeof(cli_addr);
       int rc = select(maxfd, &rd_set, NULL, NULL, NULL);
       if (-1 == rc) {
+       // stop hogging processor in case of error
+	 sleep(1);
          continue;
       }
 


### PR DESCRIPTION
TCXB8-3706 : SYS_SH_Syseventd_restart marker
Reason for change: syseventd must not be started,
                   even if sysevent_open() fails
Test Procedure: refer to jira
Risks: Low
Priority:P1
Signed-off-by: abhishek_kumaracee2@comcast.com