### PR TITLE
RDKB-58679: Add PSM changes for vlan

### DIFF
--- a/source/scripts/init/src/apply_system_defaults/apply_system_defaults.c
+++ b/source/scripts/init/src/apply_system_defaults/apply_system_defaults.c
@@ -1222,6 +1222,10 @@ static int ApplyPartnersObjectItemsIntoSysevents( char *pcPartnerID )
                {
                   sysevent_set (global_fd, global_id, "HotSpotSupport", value, 0);
                }
+               else if ( 0 == strcmp ( key, "Device.X_RDK_Features.VlanDiscovery.Enable") )
+               {
+                  sysevent_set (global_fd, global_id, "VlanDiscoverySupport", value, 0);
+               }
 
                pCJsonChildParam = pCJsonChildParam->next;
             }


### PR DESCRIPTION
Reason for change:
1. Set values in syscfg.db from json file

Test Procedure:
1. Check if default PSM values are showing

Change-Id: Ic7daf4beca61f9c61888372d7ebc95e21ad22d46
Risks: Low

(cherry picked from commit 1227e9eb7666d292edad0e99a9dfdd1a5f0c0c24)