### PR TITLE
RDKB-61703: Update default secure URLs for xconf and T2 in Utopia

### DIFF
--- a/source/scripts/init/defaults/system_defaults_arm
+++ b/source/scripts/init/defaults/system_defaults_arm
@@ -1379,7 +1379,7 @@ $ddns_server_retryinterval_5=660
 
 #Control firmware update exclusion
 $AutoExcludedEnabled=false
-$AutoExcludedURL=https://xconf.xcal.tv/xconf/swu/stb
+$AutoExcludedURL=https://secure.xconfds.coast.xcal.tv
 
 #HWSelfTest Enable(Default =false)
 $hwHealthTest=false


### PR DESCRIPTION
Reason for change: Update default URL 
Test Procedure: As mentioned in the ticket
Risks: Medium