### PR TITLE
RDKB-61703: Update default secure URLs for xconf and T2 in Utopia

### DIFF
--- a/source/scripts/init/defaults/system_defaults_arm
+++ b/source/scripts/init/defaults/system_defaults_arm
@@ -1259,7 +1259,7 @@ $XconfRecoveryUrl=https://recovery.xconfds.coast.xcal.tv/xconf/swu/stb
 #Defaults for Telemetry T2 Enable
 $T2Enable=true
 $T2Version=2.0.1
-$T2ConfigURL=https://xconf.xcal.tv/loguploader/getT2Settings
+$T2ConfigURL=https://secure.xconfds.coast.xcal.tv/loguploader/getT2Settings
 
 #Defaults for mTLS in T2
 $T2mTLSEnable=true
@@ -1379,7 +1379,7 @@ $ddns_server_retryinterval_5=660
 
 #Control firmware update exclusion
 $AutoExcludedEnabled=false
-$AutoExcludedURL=https://xconf.xcal.tv/xconf/swu/stb
+$AutoExcludedURL=https://secure.xconfds.coast.xcal.tv/xconf/swu/stb
 
 #HWSelfTest Enable(Default =false)
 $hwHealthTest=false

--- a/source/scripts/init/defaults/system_defaults_bci
+++ b/source/scripts/init/defaults/system_defaults_bci
@@ -1207,7 +1207,7 @@ $XconfRecoveryUrl=https://recovery.xconfds.coast.xcal.tv/xconf/swu/stb
 #Defaults for Telemetry T2 Enable
 $T2Enable=true
 $T2Version=2.0.1
-$T2ConfigURL=https://xconf.xcal.tv/loguploader/getT2Settings
+$T2ConfigURL=https://secure.xconfds.coast.xcal.tv/loguploader/getT2Settings
 
 #Defaults for mTLS in T2
 $T2mTLSEnable=true
@@ -1269,7 +1269,7 @@ $ddns_server_retryinterval_5=660
 
 #Control firmware update exclusion
 $AutoExcludedEnabled=false
-$AutoExcludedURL=https://xconf.xcal.tv/xconf/swu/stb
+$AutoExcludedURL=https://secure.xconfds.coast.xcal.tv/xconf/swu/stb
 
 #HWSelfTest Enable(Default =false)
 $hwHealthTest=false

--- a/source/scripts/init/defaults/system_defaults_xd4
+++ b/source/scripts/init/defaults/system_defaults_xd4
@@ -1248,7 +1248,7 @@ $XconfRecoveryUrl=https://recovery.xconfds.coast.xcal.tv/xconf/swu/stb
 #Defaults for Telemetry T2 Enable
 $T2Enable=true
 $T2Version=2.0.1
-$T2ConfigURL=https://xconf.xcal.tv/loguploader/getT2Settings
+$T2ConfigURL=https://secure.xconfds.coast.xcal.tv/loguploader/getT2Settings
 
 #Defaults for mTLS in T2
 $T2mTLSEnable=true
@@ -1368,7 +1368,7 @@ $ddns_server_retryinterval_5=660
 
 #Control firmware update exclusion
 $AutoExcludedEnabled=false
-$AutoExcludedURL=https://xconf.xcal.tv/xconf/swu/stb
+$AutoExcludedURL=https://secure.xconfds.coast.xcal.tv/xconf/swu/stb
 
 #HWSelfTest Enable(Default =false)
 $hwHealthTest=false


### PR DESCRIPTION
Reason for change: Defaulting secure URLs
Test Procedure: As mentioned in ticket
Risks: Medium
Priority: P1