### PR TITLE
RDKB-60232 : Option 82 rules for Amenity bridges

### DIFF
--- a/source/firewall/firewall.c
+++ b/source/firewall/firewall.c
@@ -3119,6 +3119,7 @@ static int prepare_globals_from_configuration(void)
 
 
 #if defined (AMENITIES_NETWORK_ENABLED)
+#define AMENITY_QUEUE_NUM_START 61
 void updateAmenityNetworkRules(FILE *filter_fp , FILE *mangle_fp , int iptype )
 {
    char query[MAX_QUERY];
@@ -3166,13 +3167,12 @@ void updateAmenityNetworkRules(FILE *filter_fp , FILE *mangle_fp , int iptype )
       FIREWALL_DEBUG(" Applying Amenity network IPv%d rules for %s \n" COMMA iptype COMMA bridgename);
       if(iptype == AF_INET)
       {
-         //will be enabling option 82 rules once prod team confirms
-         //fprintf(filter_fp, "-A FORWARD -o %s -p udp --dport=67:68 -j NFQUEUE --queue-bypass --queue-num %d\n", bridgename, idx+1);
+         //DHCP option 82 handling rule for Amenity bridge interfaces
+         fprintf(filter_fp, "-A FORWARD -o %s -p udp --dport=67:68 -j NFQUEUE --queue-bypass --queue-num %d\n", bridgename, AMENITY_QUEUE_NUM_START+idx);
          fprintf(mangle_fp, "-A POSTROUTING -o %s -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1360 \n" , bridgename);
       }
       else
       {
-         // Adding Accept rule for Amenity interface
          fprintf(filter_fp, "-A INPUT -i %s -j ACCEPT  \n" , bridgename );
          // Allow forward within same Amenity network interface
          fprintf(filter_fp, "-A FORWARD -i %s -o %s -j ACCEPT\n", bridgename, bridgename);


### PR DESCRIPTION
Reason for change: Option 82 handling related rules for Amenity bridges Queue number is used  61 to 63 which is not used for any other service Test Procedure: option82 related firewall rules for tcp and udp should be applied for respective interface queue number Risks: Low
Priority: P1
Signed-off-by: vijayaragavalu_sundaresan2@comcast.com