### PR TITLE
RDKB-61412 : Add RDKBPOD generic vendor name for all extender devices

### DIFF
--- a/source/scripts/init/service.d/service_dhcp_server/dhcp_server_functions.sh
+++ b/source/scripts/init/service.d/service_dhcp_server/dhcp_server_functions.sh
@@ -1082,6 +1082,7 @@ fi
      echo "dhcp-option=vendor:HIXE12AWR,43,tag=123" >> $LOCAL_DHCP_CONF
      echo "dhcp-option=vendor:WNXE12AWR,43,tag=123" >> $LOCAL_DHCP_CONF
      echo "dhcp-option=vendor:WNXL11BWL,43,tag=123" >> $LOCAL_DHCP_CONF
+     echo "dhcp-option=vendor:RDKBPOD,43,tag=123" >> $LOCAL_DHCP_CONF
    fi
 
    if [ "dns_only" != "$3" ] ; then

--- a/source/service_dhcp/dhcp_server_functions.c
+++ b/source/service_dhcp/dhcp_server_functions.c
@@ -1568,6 +1568,7 @@ int prepare_dhcp_conf (char *input)
         fprintf(l_fLocal_Dhcp_ConfFile, "dhcp-option=vendor:WNXE12AWR,43,tag=123\n");
         fprintf(l_fLocal_Dhcp_ConfFile, "dhcp-option=vendor:SE401,43,tag=123\n");
         fprintf(l_fLocal_Dhcp_ConfFile, "dhcp-option=vendor:WNXL11BWL,43,tag=123\n");
+        fprintf(l_fLocal_Dhcp_ConfFile, "dhcp-option=vendor:RDKBPOD,43,tag=123\n");
 
         // Set dnsmasq tag for XLE as "extender".
         fprintf(l_fLocal_Dhcp_ConfFile, "dhcp-vendorclass=set:extender,WNXL11BWL\n");


### PR DESCRIPTION
Reason for change: This fix will response with option 43 when a dhcp request or discover is received with vendor name RDKBPOD. 
Test Procedure: Make sure pod is connecting in wifi and eth backhaul 
Risks: None