### PR TITLE
SHARMAN-1210:Add telemetry support to report FW info from both banks

### DIFF
--- a/source/scripts/init/service.d/service_crond.sh
+++ b/source/scripts/init/service.d/service_crond.sh
@@ -190,7 +190,7 @@ service_start ()
           addCron "48 * * * *  sh /etc/sky/monitor_dhd_dump.sh &"
       fi
 
-      if [ "$BOX_TYPE" != "SR300" ] && [ "$BOX_TYPE" != "SE501" ] && [ "$BOX_TYPE" != "SR213" ] && [ "$BOX_TYPE" != "WNXL11BWL" ] && [ "$BOX_TYPE" != "SCER11BEL" ]; then
+      if [ "$BOX_TYPE" != "SR300" ] && [ "$BOX_TYPE" != "SE501" ] && [ "$BOX_TYPE" != "WNXL11BWL" ] && [ "$BOX_TYPE" != "SCER11BEL" ]; then
          #RDKB-43895 log the firmware bank informations in selfheal log
          echo "5 */12  * * *  /usr/bin/FwBankInfo" >> $CRONTAB_FILE
       fi


### PR DESCRIPTION
SHARMAN-1210:Add telemetry support to report FW info from both banks

Reason for change: Enable the crontab job entry to execute the
    FwBankInfo binary on Hub6

Test Procedure: NA

Priority:P1

Risks:Low