### PR TITLE
RDKB-60956: Default OAUTH AuthMode feature to SSO in firmware

### DIFF
--- a/source/scripts/init/src/apply_system_defaults/apply_system_defaults.c
+++ b/source/scripts/init/src/apply_system_defaults/apply_system_defaults.c
@@ -2757,6 +2757,10 @@ static int apply_partnerId_default_values (char *data, char *PartnerID)
                                             if( pcAuthMode != NULL )
                                             {
                                                 set_syscfg_partner_values( pcAuthMode, "OAUTHAuthMode" );
+												if (strcmp(pcAuthMode, "sso") == 0)
+                                                {
+                                                    APPLY_PRINT("%s - OAuth AuthMode defaulted to SSO\n", __FUNCTION__);
+                                                }
                                                 pcAuthMode = NULL;
                                             }
                                             else


### PR DESCRIPTION
Reason for change: Added logline to indicate SSO is defaulted
Test Procedure: As mentioned in the ticket
Risks: Medium