### PR TITLE
RDKCOM-5422: RDKBDEV-3258 Remove UTOPIA mcast services from the build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -241,6 +241,18 @@ AC_ARG_ENABLE([hotspot],
         [enable_hotspot=true])
 AM_CONDITIONAL([ENABLE_HOTSPOT_SERVICE], [test x$enable_hotspot = xtrue])
 
+AC_ARG_ENABLE([igmpmld],
+         AS_HELP_STRING([--enable-igmpmld],[Enable igmpmld]),
+        [
+          case "${enableval}" in
+            yes) enable_igmpmld=true ;;
+            no) enable_igmpmld=false ;;
+            *) AC_MSG_ERROR([bad value ${enableval} for --enable-igmpmld]) ;;
+          esac
+           ],
+        [enable_igmpmld=true])
+AM_CONDITIONAL([ENABLE_MCAST_SERVICE], [test x$enable_igmpmld = xtrue])
+
 AC_CONFIG_FILES(
 	Makefile
 	source/Makefile

--- a/source/scripts/init/c_registration/Makefile.am
+++ b/source/scripts/init/c_registration/Makefile.am
@@ -49,8 +49,6 @@ bin_PROGRAMS = \
     03_connectcheck \
     09_xdns \
     10_firewall \
-    10_mcastproxy \
-    10_mldproxy \
     10_ntpd \
     15_ccsphs \
     15_ddnsclient \
@@ -67,6 +65,10 @@ bin_PROGRAMS = \
 
 if FEATURE_RDKB_EXTENDER
 bin_PROGRAMS += 02_devicemode
+endif
+
+if ENABLE_MCAST_SERVICE
+bin_PROGRAMS += 10_mcastproxy 10_mldproxy
 endif
 
 if ENABLE_POTD_SERVICE
@@ -98,9 +100,6 @@ endif
 10_bootstrap_dns_SOURCES = 10_bootstrap_dns.c
 10_firewall_SOURCES = 10_firewall.c
 10_fpm_SOURCES = 10_fpm.c
-10_mcastproxy_SOURCES = 10_mcastproxy.c
-10_mcastsnooper_SOURCES = 10_mcastsnooper.c
-10_mldproxy_SOURCES = 10_mldproxy.c
 10_ntpclient_SOURCES = 10_ntpclient.c
 10_ntpd_SOURCES = 10_ntpd.c
 10_sysevent_proxy_SOURCES = 10_sysevent_proxy.c
@@ -129,6 +128,11 @@ endif
 
 if FEATURE_RDKB_EXTENDER
 02_devicemode_SOURCES = 02_devicemode.c
+endif
+if ENABLE_MCAST_SERVICE
+10_mcastproxy_SOURCES = 10_mcastproxy.c
+10_mcastsnooper_SOURCES = 10_mcastsnooper.c
+10_mldproxy_SOURCES = 10_mldproxy.c
 endif
 if ENABLE_POTD_SERVICE
 26_potd_SOURCES = 26_potd.c

--- a/source/scripts/init/service.d/service_misc.sh
+++ b/source/scripts/init/service.d/service_misc.sh
@@ -75,11 +75,11 @@ if [ "$RG_MD" = "1" -o "$RG_MD" = "3" ]; then
 	/etc/utopia/service.d/service_igd.sh lan-status&
 fi
 
-if [ "$RG_MD" = "1" -o "$RG_MD" = "3" ]; then
+if [[ "$RG_MD" = "1" -o "$RG_MD" = "3" ]] && [ -f /etc/utopia/service.d/service_mcastproxy.sh ]; then
 	/etc/utopia/service.d/service_mcastproxy.sh lan-status&
 fi
 
-if [ "$RG_MD" = "2" -o "$RG_MD" = "3" ]; then
+if [[ "$RG_MD" = "2" -o "$RG_MD" = "3" ]] && [ -f /etc/utopia/service.d/service_mldproxy.sh ]; then
 	/etc/utopia/service.d/service_mldproxy.sh lan-status&
 fi
 


### PR DESCRIPTION
Reason for change: Utopia should have an option to not build mcast sources if it is not required on the platform
Test Procedure: binary presence based on the flag enablement
Risks: None