### PR TITLE
RDKCOM-5387: RDKBDEV-3230: improved error checking in sysctl_iface_set()

### DIFF
--- a/source/util/utils/util.c
+++ b/source/util/utils/util.c
@@ -78,7 +78,8 @@ int sysctl_iface_set(const char *path, const char *ifname, const char *content)
     int fd;
 
     if (ifname) {
-        snprintf(buf, sizeof(buf), path, ifname);
+        if (snprintf(buf, sizeof(buf), path, ifname) >= sizeof(buf))
+            return -1;
         filename = buf;
     }
     else


### PR DESCRIPTION
Reason for change:
improved error checking in sysctl_iface_set()
Test Procedure: Sanity.
Risks: None.
Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
Priority: P1

Change-Id: I51b1e3423890468f9496508b74287bc66d09969b (cherry picked from commit ccda1b6372f534e4f32928a1fe4e9bc88f85970f)