### PR TITLE
RDKBDEV-3294 : Fix open port 21515 by default on unexpected interfaces.

### DIFF
--- a/source/firewall/firewall.c
+++ b/source/firewall/firewall.c
@@ -13121,7 +13121,7 @@ int do_block_ports(FILE *filter_fp)
 
    fprintf(filter_fp, "-A INPUT ! -i brlan0 -p tcp -m tcp --dport 49152:49153 -j DROP\n");
    fprintf(filter_fp, "-A INPUT ! -i brlan0 -p udp -m udp --dport 1900 -j DROP\n");
-   fprintf(filter_fp, "-A INPUT ! -i brlan0 -p tcp -m tcp --dport 21515 -j DROP\n");
+   fprintf(filter_fp, "-I INPUT ! -i brlan0 -p tcp -m tcp --dport 21515 -j DROP\n");
    fprintf(filter_fp, "-A INPUT ! -i brlan0 -p udp -m udp --dport 21515 -j DROP\n");
 
    /*	RDKB-22836 :


### PR DESCRIPTION
Reason for change: During NMAP scan for TCP open ports in MXL platform, we noticed that port 21515 seem to be open by default on wan0 and mta0 interfaces. This will be fixed here.
Risks: Low
Signed-off-by: Aiswarya Prasad <aprasad@maxlinear.com>