### PR TITLE
RDKCOM-5574: RDKBDEV-3417 RDKBACCL-1092 FW Upgrade is not working via tftp server configurations

### DIFF
--- a/source/firewall/firewall.c
+++ b/source/firewall/firewall.c
@@ -11987,6 +11987,7 @@ static int prepare_subtables(FILE *raw_fp, FILE *mangle_fp, FILE *nat_fp, FILE *
 
 #if defined (_PLATFORM_BANANAPI_R4_)
        isRawTableUsed = 1;
+       fprintf(raw_fp, "-F\n");
        fprintf(raw_fp, "-A OUTPUT -p udp --dport 69 -j CT --helper tftp\n");
 #endif
 

--- a/source/firewall/firewall_ipv6.c
+++ b/source/firewall/firewall_ipv6.c
@@ -414,6 +414,10 @@ int prepare_ipv6_firewall(const char *fw_file)
 
    #endif
 
+#if defined (_PLATFORM_BANANAPI_R4_)
+        fprintf(fp, "*raw\n-F\n");
+#endif
+
 	/*add rules before this*/
 #if !defined(_BWG_PRODUCT_REQ_)
 	fprintf(raw_fp, "COMMIT\n");


### PR DESCRIPTION
Reason for change: since we defined isRawTableUsed as 1, adding the raw rule for ipv6 as explicity as per codeflow
Test procedure: check the ipv6 functionality
Risks: Low