### PR TITLE
RDKCOM-5572: RDKBDEV-3415 RDKBACCL-1493 [TDK][AUTO][BPI] Device is no…

### DIFF
--- a/source/firewall/firewall.c
+++ b/source/firewall/firewall.c
@@ -12355,6 +12355,12 @@ static int prepare_subtables(FILE *raw_fp, FILE *mangle_fp, FILE *nat_fp, FILE *
 #if defined(_PLATFORM_BANANAPI_R4_)
    fprintf(filter_fp, "-I OUTPUT -o %s -p tcp --sport 49153 -j ACCEPT\n",get_current_wan_ifname());
 #endif
+   char tr69_enabled[20];
+   memset(tr69_enabled, 0, sizeof(tr69_enabled));
+   syscfg_get(NULL, "EnableTR69Binary", tr69_enabled, sizeof(tr69_enabled));
+   if (!isComcastImage &&((tr69_enabled[0] == '\0') || (strcasecmp(tr69_enabled, "true") == 0))) {
+       fprintf(filter_fp, "-A INPUT -i %s -p tcp -m tcp --dport 7547 -j ACCEPT\n",get_current_wan_ifname());
+   }
 #ifdef CONFIG_CISCO_FEATURE_CISCOCONNECT
    fprintf(filter_fp, ":%s - [0:0]\n", "pp_disabled");
    if(isGuestNetworkEnabled) {


### PR DESCRIPTION
…t accepting packets from ACS server via default Tr069 port(7547) (#279)

Reason for change: Traffic is not allowed due to inacceptance
Test procedure: Test the Tr069 feature
Risks: Low