### PR TITLE
RDKB-63927 RDKB-64336: Defaulting Direct CDN firmware download

### DIFF
--- a/source/scripts/init/defaults/system_defaults_arm
+++ b/source/scripts/init/defaults/system_defaults_arm
@@ -1454,7 +1454,7 @@ $RemDeviceDetectionTimeout=60
 $FailoverEnable=-1
 
 #Direct Download Enable default value
-$SWDLDirectEnable=false
+$SWDLDirectEnable=true
 
 #Latency Measure factory default values
 $LatencyMeasure_IPv4Enable=false

--- a/source/scripts/init/defaults/system_defaults_bci
+++ b/source/scripts/init/defaults/system_defaults_bci
@@ -1313,7 +1313,7 @@ $DscpEnabledList_2=
 $DscpSleepInterval_2=0
 
 #Direct Download Enable default value
-$SWDLDirectEnable=false
+$SWDLDirectEnable=true
 
 #DeviceType default value
 $DeviceType=PROD

--- a/source/scripts/init/defaults/system_defaults_xd4
+++ b/source/scripts/init/defaults/system_defaults_xd4
@@ -1432,7 +1432,7 @@ $GatewayRestoreAttemptCount=0
 $RemDeviceDetectionTimeout=60
 
 #Direct Download Enable default value
-$SWDLDirectEnable=false
+$SWDLDirectEnable=true
 
 #Latency Measure factory default values
 $LatencyMeasure_IPv4Enable=false


### PR DESCRIPTION
Reason for change: Defauting CDN RFC to true
Test Procedure: As mentioned in the ticket
Risk: Medium
Priority: P1

Signed-off-by: plaksh175_comcast <PiramanayagamMoneka_Lakshmi@comcast.com>