### PR TITLE
RDKB-64189: Enable ZRAM to optimize and reduce RDKB memory usage

### DIFF
--- a/source/scripts/init/defaults/system_defaults_arm
+++ b/source/scripts/init/defaults/system_defaults_arm
@@ -1509,3 +1509,11 @@ $StageEnabled=false
 
 #RdkLogger Cron - RFC flag is enabled by default
 $RdkbLogCronEnable=true
+
+#Memory swap defaults
+$MemorySwapEnable=true
+$MemorySwapDiskSizeMB=300
+$MemorySwapStatsIntervalMinutes=30
+$MemorySwapTunablesSwappiness=200
+$MemorySwapTunablesWatermarkScaleFactor=80
+$MemorySwapTunablesPageCluster=0

--- a/source/scripts/init/defaults/system_defaults_bci
+++ b/source/scripts/init/defaults/system_defaults_bci
@@ -1356,3 +1356,11 @@ $StageEnabled=false
 
 #RdkLogger Cron - RFC flag is enabled by default
 $RdkbLogCronEnable=true
+
+#Memory swap defaults
+$MemorySwapEnable=true
+$MemorySwapDiskSizeMB=300
+$MemorySwapStatsIntervalMinutes=30
+$MemorySwapTunablesSwappiness=200
+$MemorySwapTunablesWatermarkScaleFactor=80
+$MemorySwapTunablesPageCluster=0

--- a/source/scripts/init/service.d/service_crond.sh
+++ b/source/scripts/init/service.d/service_crond.sh
@@ -322,6 +322,13 @@ service_start ()
 			echo_t "This Device WAN TYPE is not DOCSIS, Needed DOCSIS type Device for WANLinkHeal"
 		fi
 
+        MEMSWAP_ENABLE=`syscfg get MemorySwapEnable`
+        if [ "$MEMSWAP_ENABLE" = "true" ]; then
+            MEMSWAP_INTERVAL=`syscfg get MemorySwapStatsIntervalMinutes`
+            if [ -n "$MEMSWAP_INTERVAL" ] && [ "$MEMSWAP_INTERVAL" -gt 0 ]; then
+                echo "*/$MEMSWAP_INTERVAL * * * * /usr/ccsp/tad/memswap_stats.sh" >> $CRONTAB_FILE
+            fi
+        fi
    fi
  
 

--- a/source/scripts/init/service.d/service_crond.sh
+++ b/source/scripts/init/service.d/service_crond.sh
@@ -326,13 +326,33 @@ service_start ()
         if [ "$MEMSWAP_ENABLE" = "true" ]; then
             MEMSWAP_INTERVAL=`syscfg get MemorySwapStatsIntervalMinutes`
             if [ -n "$MEMSWAP_INTERVAL" ] && [ "$MEMSWAP_INTERVAL" -gt 0 ]; then
-                echo "*/$MEMSWAP_INTERVAL * * * * /usr/ccsp/tad/zram_stats.sh" >> $CRONTAB_FILE
+                case "$MEMSWAP_INTERVAL" in
+                    10|12|15|20|30)
+                        # Run every MEMSWAP_INTERVAL minutes
+                        cron_minute="*/$MEMSWAP_INTERVAL"
+                        cron_hour="*"
+                        ;;
+                    60)
+                        # Run every hour at minute 0
+                        cron_minute="0"
+                        cron_hour="*"
+                        ;;
+                    120)
+                        # Run every 2 hours at minute 0
+                        cron_minute="0"
+                        cron_hour="*/2"
+                        ;;
+                    *)
+                        echo_t "Invalid MemorySwapStatsIntervalMinutes value: $MEMSWAP_INTERVAL. Please set it to one of the following values: 10, 12, 15, 20, 30, 60, or 120."
+                        ;;
+                esac
+
+                if [ -n "$cron_minute" ] && [ -n "$cron_hour" ]; then
+                    echo "$cron_minute $cron_hour * * * /usr/ccsp/tad/zram_stats.sh" >> $CRONTAB_FILE
+                fi
             fi
         fi
    fi
- 
-
-
  
    # start the cron daemon
    # echo "[utopia][registration] Starting cron daemon"

--- a/source/scripts/init/service.d/service_crond.sh
+++ b/source/scripts/init/service.d/service_crond.sh
@@ -326,7 +326,7 @@ service_start ()
         if [ "$MEMSWAP_ENABLE" = "true" ]; then
             MEMSWAP_INTERVAL=`syscfg get MemorySwapStatsIntervalMinutes`
             if [ -n "$MEMSWAP_INTERVAL" ] && [ "$MEMSWAP_INTERVAL" -gt 0 ]; then
-                echo "*/$MEMSWAP_INTERVAL * * * * /usr/ccsp/tad/memswap_stats.sh" >> $CRONTAB_FILE
+                echo "*/$MEMSWAP_INTERVAL * * * * /usr/ccsp/tad/zram_stats.sh" >> $CRONTAB_FILE
             fi
         fi
    fi


### PR DESCRIPTION
The following changes are part of a larger effort to enable a ZRAM SWAP partition for Broadband devices:

- The state of the RFC is managed by newly-defined `SysCfg` key-value pairs
- Telemetry markers are reported via a new `zram_stats.sh` script in `test-and-diagnostic` which runs on a cron