### PR TITLE
RDKB-64498 : AutoReboot Cron is not set

### DIFF
--- a/source/scripts/init/defaults/system_defaults_arm
+++ b/source/scripts/init/defaults/system_defaults_arm
@@ -1517,3 +1517,6 @@ $MemorySwapStatsIntervalMinutes=30
 $MemorySwapTunablesSwappiness=200
 $MemorySwapTunablesWatermarkScaleFactor=80
 $MemorySwapTunablesPageCluster=0
+
+#Autoreboot is enabled by default
+$AutoReboot=true

--- a/source/scripts/init/defaults/system_defaults_bci
+++ b/source/scripts/init/defaults/system_defaults_bci
@@ -1364,3 +1364,6 @@ $MemorySwapStatsIntervalMinutes=30
 $MemorySwapTunablesSwappiness=200
 $MemorySwapTunablesWatermarkScaleFactor=80
 $MemorySwapTunablesPageCluster=0
+
+#Autoreboot is enabled by default
+$AutoReboot=true


### PR DESCRIPTION
Reason for change: Default syscfg value for AutoReboot is not available because which set is getting failed for the first time.
Test Procedure: Check whether the Default value is true after boot-up.
Priority: P1
Risks: None