### PR TITLE
SHARMAN-4067 Delay in NTP sync observed after FactoryReset

### DIFF
--- a/source/scripts/init/service.d/service_connectivitycheck.sh
+++ b/source/scripts/init/service.d/service_connectivitycheck.sh
@@ -91,7 +91,7 @@ while true; do
         fi
         exit 0
     fi
-    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+    HTTP_CODE=$(curl -s --connect-timeout 3 --max-time 5 -o /dev/null -w "%{http_code}" "$URL")
     CURL_STATUS=$?
     uptime=$(cut -d. -f1 /proc/uptime)
     uptime_ms=$((uptime*1000))


### PR DESCRIPTION
SHARMAN-4067 Delay in NTP sync observed after FactoryReset

Reason for change: Adding a timeout value and maximum retry in the curl command to avoid indefinite stuck of curl waiting for the response

Test Procedure: NA

Risks: LOW

Priority: P1