### PR TITLE
XB10-2633: [26Q2_Sprint][OS][Residential]Connected clients are not re…

### DIFF
--- a/source/service_routed/service_routed.c
+++ b/source/service_routed/service_routed.c
@@ -922,10 +922,11 @@ STATIC int gen_zebra_conf(int sefd, token_t setok)
         "!log stdout\n"
         "log file /var/tmp/zebra.log errors\n"
         "table 255\n";
-#if defined(MULTILAN_FEATURE) || defined(CISCO_CONFIG_DHCPV6_PREFIX_DELEGATION) || defined(_ONESTACK_PRODUCT_REQ_)
     int i = 0;
-    unsigned int l2_insts[4] = {0};
     unsigned int enabled_iface_num = 0;
+#if defined(MULTILAN_FEATURE) || defined(CISCO_CONFIG_DHCPV6_PREFIX_DELEGATION) || defined(_ONESTACK_PRODUCT_REQ_)
+    bool multilan_pd_enabled = false;
+    unsigned int l2_insts[4] = {0};
     char evt_name[64] = {0};
 #endif
     int  StaticDNSServersEnabled = 0;
@@ -1166,34 +1167,38 @@ STATIC int gen_zebra_conf(int sefd, token_t setok)
     syscfg_get(NULL, "last_erouter_mode", rtmod, sizeof(rtmod));
 
 
-#if defined(MULTILAN_FEATURE) || defined(CISCO_CONFIG_DHCPV6_PREFIX_DELEGATION) || defined (_ONESTACK_PRODUCT_REQ_)
-    int multilan_enabled = 0;
-    int pd_enabled = 0;
-
-#if defined(MULTILAN_FEATURE)
-    multilan_enabled = 1;
-#endif
-#if defined(CISCO_CONFIG_DHCPV6_PREFIX_DELEGATION)
-    pd_enabled = 1;
-#endif
-
-    #ifdef _ONESTACK_PRODUCT_REQ_
-        pd_enabled = isFeatureSupportedInCurrentMode(FEATURE_IPV6_DELEGATION);
-    #endif
-
-    if (pd_enabled || multilan_enabled)
-    {
+#if defined(MULTILAN_FEATURE) || defined(CISCO_CONFIG_DHCPV6_PREFIX_DELEGATION) || defined(_ONESTACK_PRODUCT_REQ_)
     get_active_lanif(sefd, setok, l2_insts, &enabled_iface_num);
+    #ifdef _ONESTACK_PRODUCT_REQ_
+    if (isFeatureSupportedInCurrentMode(FEATURE_IPV6_DELEGATION))
+    {
+        multilan_pd_enabled = true;   // runtime-controlled
+    }
+    else
+    {
+        enabled_iface_num = 1;            // single execution
+    }
+    #else
+        multilan_pd_enabled = true;       // Cisco/MULTILAN → always enabled
+    #endif //_ONESTACK_PRODUCT_REQ_
+#else 
+    enabled_iface_num = 1;            // single execution
+#endif 
+
     for (i = 0; i < enabled_iface_num; i++)
     {
-        snprintf(evt_name, sizeof(evt_name), "multinet_%d-name", l2_insts[i]);
-        sysevent_get(sefd, setok, evt_name, lan_if, sizeof(lan_if));
-        snprintf(evt_name, sizeof(evt_name), "ipv6_%s-prefix", lan_if);
-        sysevent_get(sefd, setok, evt_name, prefix, sizeof(prefix));
-        snprintf(evt_name, sizeof(evt_name), "ipv6_%s-addr", lan_if);
-        sysevent_get(sefd, setok, evt_name, lan_addr, sizeof(lan_addr));
-#endif
-//RDKB-47758
+#if defined(MULTILAN_FEATURE) || defined(CISCO_CONFIG_DHCPV6_PREFIX_DELEGATION) || defined(_ONESTACK_PRODUCT_REQ_)
+	if (multilan_pd_enabled )
+	{
+	    snprintf(evt_name, sizeof(evt_name), "multinet_%d-name", l2_insts[i]);
+	    sysevent_get(sefd, setok, evt_name, lan_if, sizeof(lan_if));
+	    snprintf(evt_name, sizeof(evt_name), "ipv6_%s-prefix", lan_if);
+	    sysevent_get(sefd, setok, evt_name, prefix, sizeof(prefix));
+	    snprintf(evt_name, sizeof(evt_name), "ipv6_%s-addr", lan_if);
+	    sysevent_get(sefd, setok, evt_name, lan_addr, sizeof(lan_addr));
+	}
+#endif 
+	//RDKB-47758
 #ifdef WAN_FAILOVER_SUPPORTED
 	if (gIpv6AddrAssignment == ULA_IPV6)
     {
@@ -1776,10 +1781,7 @@ STATIC int gen_zebra_conf(int sefd, token_t setok)
     fprintf(fp, "interface %s\n", lan_if);
     fprintf(fp, "   ip irdp multicast\n");
 
-#if defined(MULTILAN_FEATURE) || defined(CISCO_CONFIG_DHCPV6_PREFIX_DELEGATION) || defined(_ONESTACK_PRODUCT_REQ_)
     } //for (i = 0; i < enabled_iface_num; i++)
-    }
-#endif
 
 #if !defined(CISCO_CONFIG_DHCPV6_PREFIX_DELEGATION) || defined(_ONESTACK_PRODUCT_REQ_)
 #ifdef _ONESTACK_PRODUCT_REQ_


### PR DESCRIPTION
…ceiving IPv6 addresses and do not have IPv6 internet connectivity. (#298)

Reason for change: Zebra configuration for brlan0 in OS enabled image has been added only if PD has been enabled. So modified that check, so brlan0 configuration for OS -enabled(PD enabled case), OS-enabled(PD-disabled case ) and otehr legacy casess Test Procedure:
  - Build OneStack Image
- In Both mode, Check dibbler and zebra started with proper configurations and server.conf has prefix-delegation class
  - Check connected clients are receiving ipv6address Priority: P1

- [-] Is this a User Story (US)? This is a bug ticket 

- [x] Have all dependent PRs from other components been listed ?

- [x] Does the commit message include both the User Story ticket and the Subtask ticket?

- [x] Will be all changes related to the User Story squashed and merged in a single commit?

- [x] Has the PR been raised only after completing all changes for the User Story (no partial changes)?

- [x] Has code development for the User Story been completed?

- [x] If yes, has the Gerrit topic or list of all dependent PRs across components (including meta-layer changes) been shared? https://gerrit.teamccp.com/#/c/953000

- [x] Is there a validation log available in the Jira ticket for verifying builds with the updated generic-srcrev.inc across all platforms?

[XB10-2633logs.txt](https://github.com/user-attachments/files/27482290/XB10-2633logs.txt)