### PR TITLE
RDKB-64265:  Removing erouter0 hardcode for reusability for different wan interface

### DIFF
--- a/source/firewall/firewall_ipv6.c
+++ b/source/firewall/firewall_ipv6.c
@@ -268,14 +268,14 @@ int prepare_ipv6_firewall(const char *fw_file)
 	if (NULL == nat_fp) {
 		ret=-2;
 		goto clean_up_files;
-        }
+	}
 #if defined (_ONESTACK_PRODUCT_REQ_)
 	char sysEventName[256] ={0};
 	memset(ipv6_delegation_prefix, 0, sizeof(ipv6_delegation_prefix));
 	if (isFeatureSupportedInCurrentMode(FEATURE_IPV6_DELEGATION))
 	{
-	    snprintf(sysEventName, sizeof(sysEventName), "tr_%s_dhcpv6_client_v6pref", current_wan_ifname);
-	    sysevent_get(sysevent_fd, sysevent_token, sysEventName, ipv6_delegation_prefix, sizeof(ipv6_delegation_prefix));
+		snprintf(sysEventName, sizeof(sysEventName), "tr_%s_dhcpv6_client_v6pref", current_wan_ifname);
+		sysevent_get(sysevent_fd, sysevent_token, sysEventName, ipv6_delegation_prefix, sizeof(ipv6_delegation_prefix));
 	}
 #endif 
 

--- a/source/firewall/firewall_ipv6.c
+++ b/source/firewall/firewall_ipv6.c
@@ -186,10 +186,9 @@ int numifs = sizeof(ifnames) / sizeof(*ifnames);
 #define V6_BLOCKFRAGIPPKT   "v6_BlockFragIPPkts"
 #define V6_PORTSCANPROTECT  "v6_PortScanProtect"
 #define V6_IPFLOODDETECT    "v6_IPFloodDetect"
-
-#ifdef _ONESTACK_PRODUCT_REQ_
-#define COSA_DML_DHCPV6_CLIENT_IFNAME                 "erouter0"
-#define COSA_DML_DHCPV6C_PREF_SYSEVENT_NAME           "tr_"COSA_DML_DHCPV6_CLIENT_IFNAME"_dhcpv6_client_v6pref"
+#define BUF_SIZE 128
+#if defined (_ONESTACK_PRODUCT_REQ_)
+static char ipv6_delegation_prefix[BUF_SIZE+1] ={0};
 #endif
 /*
  ****************************************************************
@@ -269,9 +268,17 @@ int prepare_ipv6_firewall(const char *fw_file)
 	if (NULL == nat_fp) {
 		ret=-2;
 		goto clean_up_files;
+        }
+#if defined (_ONESTACK_PRODUCT_REQ_)
+	char sysEventName[256] ={0};
+	if (isFeatureSupportedInCurrentMode(FEATURE_IPV6_DELEGATION))
+	{
+	    snprintf(sysEventName, sizeof(sysEventName), "tr_%s_dhcpv6_client_v6pref", current_wan_ifname);
+	    memset(ipv6_delegation_prefix, 0, sizeof(ipv6_delegation_prefix));
+	    sysevent_get(sysevent_fd, sysevent_token, sysEventName, ipv6_delegation_prefix, sizeof(ipv6_delegation_prefix));
 	}
-        
-      
+#endif 
+
    #ifdef RDKB_EXTENDER_ENABLED  
 
    if (isExtProfile() == 0)
@@ -1245,7 +1252,7 @@ v6GPFirewallRuleNext:
       fprintf(fp, "-A FORWARD -d 0::/96  -j LOG_FORWARD_DROP\n");
 
       // Basic RPF check on the egress & ingress traffic
-      char prefix[129];
+      char prefix[BUF_SIZE+1];
       prefix[0] = 0;
 #ifdef FEATURE_MAPE
       char prev_prefix[MAX_QUERY] = {0};
@@ -1263,14 +1270,14 @@ v6GPFirewallRuleNext:
 #ifdef _ONESTACK_PRODUCT_REQ_
       if(isFeatureSupportedInCurrentMode(FEATURE_IPV6_DELEGATION))
       {
-	  sysevent_get(sysevent_fd, sysevent_token, COSA_DML_DHCPV6C_PREF_SYSEVENT_NAME, prefix, sizeof(prefix));
+	  snprintf(prefix, sizeof(prefix), "%s", ipv6_delegation_prefix);
       }
       else
       {
-	  sysevent_get(sysevent_fd, sysevent_token, "ipv6_prefix", prefix, sizeof(prefix));
+	 sysevent_get(sysevent_fd, sysevent_token, "ipv6_prefix", prefix, sizeof(prefix));
       }
 #else
-	  sysevent_get(sysevent_fd, sysevent_token, "ipv6_prefix", prefix, sizeof(prefix));
+	 sysevent_get(sysevent_fd, sysevent_token, "ipv6_prefix", prefix, sizeof(prefix));
 #endif
       }
 
@@ -1278,7 +1285,7 @@ v6GPFirewallRuleNext:
 #ifdef _ONESTACK_PRODUCT_REQ_
       if(isFeatureSupportedInCurrentMode(FEATURE_IPV6_DELEGATION))
       {
-         sysevent_get(sysevent_fd, sysevent_token, COSA_DML_DHCPV6C_PREF_SYSEVENT_NAME, prefix, sizeof(prefix));
+	  snprintf(prefix, sizeof(prefix), "%s", ipv6_delegation_prefix);
       }
       else
       {
@@ -1300,7 +1307,7 @@ v6GPFirewallRuleNext:
 #if defined (_COSA_FOR_BCI_) || defined (_ONESTACK_PRODUCT_REQ_)
          /* adding forward rule for PD traffic */
 #ifdef _ONESTACK_PRODUCT_REQ_
-      if(isFeatureSupportedInCurrentMode(FEATURE_IPV6_DELEGATION))
+      if (isFeatureSupportedInCurrentMode(FEATURE_IPV6_DELEGATION))
       {
          fprintf(fp, "-A FORWARD -s %s -i %s -j ACCEPT\n", prefix, lan_ifname);
 	 if (strncasecmp(firewall_levelv6, "Custom", strlen("Custom")) == 0)
@@ -2121,8 +2128,8 @@ typedef enum{
 void applyRoutingRules(FILE* fp,ipv6_type type)
 {
        FIREWALL_DEBUG("Entering applyRoutingRules, ipv6_type is %d \n" COMMA type);
-         char prefix[129];
-         prefix[0] = 0;
+         char prefix[BUF_SIZE+1];
+	 memset(prefix,0,sizeof(prefix));
          int i ;
          if ( ULA_IPV6 == type)
 	 {
@@ -2130,22 +2137,22 @@ void applyRoutingRules(FILE* fp,ipv6_type type)
 	 }
          else
 	 {
-#ifdef _ONESTACK_PRODUCT_REQ_
-	     if(isFeatureSupportedInCurrentMode(FEATURE_IPV6_DELEGATION))
+         #ifdef _ONESTACK_PRODUCT_REQ_
+	     if(isFeatureSupportedInCurrentMode(FEATURE_IPV6_DELEGATION)) 
 	     {
-		 sysevent_get(sysevent_fd, sysevent_token, COSA_DML_DHCPV6C_PREF_SYSEVENT_NAME, prefix, sizeof(prefix));
+		 snprintf(prefix, sizeof(prefix), "%s", ipv6_delegation_prefix);
 	     }
 	     else
 	     {
 		 sysevent_get(sysevent_fd, sysevent_token, "ipv6_prefix", prefix, sizeof(prefix));
 	     }
-#else
+         #else
 	     sysevent_get(sysevent_fd, sysevent_token, "ipv6_prefix", prefix, sizeof(prefix));
-#endif
+         #endif
 	 }
-	 if (strlen(prefix) != 0 )
+	 if (strlen(prefix) != 0)
          {
-      char *token_pref =NULL;
+		 char *token_pref =NULL;
          token_pref = strtok(prefix,"/");
                   for(i = 0; i < mesh_wan_ipv6_num; i++)
                   {

--- a/source/firewall/firewall_ipv6.c
+++ b/source/firewall/firewall_ipv6.c
@@ -276,7 +276,6 @@ int prepare_ipv6_firewall(const char *fw_file)
 	{
 	    snprintf(sysEventName, sizeof(sysEventName), "tr_%s_dhcpv6_client_v6pref", current_wan_ifname);
 	    memset(ipv6_delegation_prefix, 0, sizeof(ipv6_delegation_prefix));
-	    memset(ipv6_delegation_prefix, 0, sizeof(ipv6_delegation_prefix));
 	    sysevent_get(sysevent_fd, sysevent_token, sysEventName, ipv6_delegation_prefix, sizeof(ipv6_delegation_prefix));
 	}
    #endif
@@ -2130,8 +2129,8 @@ typedef enum{
 void applyRoutingRules(FILE* fp,ipv6_type type)
 {
        FIREWALL_DEBUG("Entering applyRoutingRules, ipv6_type is %d \n" COMMA type);
-         char prefix[64] ;
-         memset(prefix,0,sizeof(prefix));
+         char prefix[129];
+         prefix[0] = 0;
          int i ;
          if ( ULA_IPV6 == type)
 	 {

--- a/source/firewall/firewall_ipv6.c
+++ b/source/firewall/firewall_ipv6.c
@@ -186,9 +186,9 @@ int numifs = sizeof(ifnames) / sizeof(*ifnames);
 #define V6_BLOCKFRAGIPPKT   "v6_BlockFragIPPkts"
 #define V6_PORTSCANPROTECT  "v6_PortScanProtect"
 #define V6_IPFLOODDETECT    "v6_IPFloodDetect"
-#define BUF_SIZE 128
+#define IPV6_PREFIX_BUF_LEN 128
 #if defined (_ONESTACK_PRODUCT_REQ_)
-static char ipv6_delegation_prefix[BUF_SIZE+1] ={0};
+static char ipv6_delegation_prefix[IPV6_PREFIX_BUF_LEN+1] ={0};
 #endif
 /*
  ****************************************************************
@@ -271,10 +271,10 @@ int prepare_ipv6_firewall(const char *fw_file)
         }
 #if defined (_ONESTACK_PRODUCT_REQ_)
 	char sysEventName[256] ={0};
+	memset(ipv6_delegation_prefix, 0, sizeof(ipv6_delegation_prefix));
 	if (isFeatureSupportedInCurrentMode(FEATURE_IPV6_DELEGATION))
 	{
 	    snprintf(sysEventName, sizeof(sysEventName), "tr_%s_dhcpv6_client_v6pref", current_wan_ifname);
-	    memset(ipv6_delegation_prefix, 0, sizeof(ipv6_delegation_prefix));
 	    sysevent_get(sysevent_fd, sysevent_token, sysEventName, ipv6_delegation_prefix, sizeof(ipv6_delegation_prefix));
 	}
 #endif 
@@ -1252,7 +1252,7 @@ v6GPFirewallRuleNext:
       fprintf(fp, "-A FORWARD -d 0::/96  -j LOG_FORWARD_DROP\n");
 
       // Basic RPF check on the egress & ingress traffic
-      char prefix[BUF_SIZE+1];
+      char prefix[IPV6_PREFIX_BUF_LEN+1];
       prefix[0] = 0;
 #ifdef FEATURE_MAPE
       char prev_prefix[MAX_QUERY] = {0};
@@ -2128,7 +2128,7 @@ typedef enum{
 void applyRoutingRules(FILE* fp,ipv6_type type)
 {
        FIREWALL_DEBUG("Entering applyRoutingRules, ipv6_type is %d \n" COMMA type);
-         char prefix[BUF_SIZE+1];
+         char prefix[IPV6_PREFIX_BUF_LEN+1];
 	 memset(prefix,0,sizeof(prefix));
          int i ;
          if ( ULA_IPV6 == type)


### PR DESCRIPTION
Test Procedure:
  - Build OneStack Image
  - In Business-mode, Check dibbler server is started and server.conf has prefix-delegation class
  - In Residential-mode,  check whether device behaves as a non-CBR device Risks: None Priority: P1

- [] Is this a User Story (US)? This is a bug ticket

- [x] Have all dependent PRs from other components been listed ?

- [x] Does the commit message include both the User Story ticket and the Subtask ticket?

- [x] Will be all changes related to the User Story squashed and merged in a single commit?

- [x]  Has the PR been raised only after completing all changes for the User Story (no partial changes)?

- [x] Has code development for the User Story been completed?

- [x] If yes, has the Gerrit topic or list of all dependent PRs across components (including meta-layer changes) been shared? https://gerrit.teamccp.com/#/c/953000/

- [x] Is there a validation log available in the Jira ticket for verifying builds with the updated generic-srcrev.inc across all platforms?