### PR TITLE
RDKBACCL-1787: Upstreaming the utopia patches from meta-rdk-bsp-arm

### DIFF
--- a/source/firewall/firewall.c
+++ b/source/firewall/firewall.c
@@ -1190,7 +1190,11 @@ int do_mapt_rules_v4(FILE *nat_fp, FILE *filter_fp, FILE *mangle_fp)
 
     /* Add POSTROUTING rule. */
 #if defined(IVI_KERNEL_SUPPORT)
+#if define(_PLATFORM_GENERICARM_)
+    fprintf(nat_fp, "-A POSTROUTING -o %s -j %s\n",current_wan_ifname,MAPT_NAT_IPV4_POST_ROUTING_TABLE);
+#else
     fprintf(nat_fp, "-A POSTROUTING -o %s -j %s\n",get_current_wan_ifname(),MAPT_NAT_IPV4_POST_ROUTING_TABLE);
+#endif
 #elif defined(NAT46_KERNEL_SUPPORT) || defined (FEATURE_SUPPORT_MAPT_NAT46)
     fprintf(nat_fp, "-A POSTROUTING -o %s -j %s\n", NAT46_INTERFACE, MAPT_NAT_IPV4_POST_ROUTING_TABLE);
 #endif
@@ -1301,10 +1305,22 @@ int do_mapt_rules_v4(FILE *nat_fp, FILE *filter_fp, FILE *mangle_fp)
                     finalPortValue = port;
             }
 #if defined(IVI_KERNEL_SUPPORT)
+#if defined(_PLATFORM_GENERICARM_)
+	    fprintf(nat_fp, "-A %s -o %s -p tcp --sport %d:%d -j SNAT --to-source %s:%d-%d\n", MAPT_NAT_IPV4_POST_ROUTING_TABLE, current_wan_ifname, initialPortValue, finalPortValue, ipaddress_str,
+                     initialPortValue, finalPortValue);
+#else
             fprintf(nat_fp, "-A %s -o %s -p tcp --sport %d:%d -j SNAT --to-source %s:%d-%d\n", MAPT_NAT_IPV4_POST_ROUTING_TABLE, get_current_wan_ifname(), initialPortValue, finalPortValue, ipaddress_str,
                     initialPortValue, finalPortValue);
+#endif
+#if defined(_PLATFORM_GENERICARM_)
+	    fprintf(nat_fp, "-A %s -o %s -p udp --sport %d:%d -j SNAT --to-source %s:%d-%d\n",MAPT_NAT_IPV4_POST_ROUTING_TABLE, current_wan_ifname, initialPortValue, finalPortValue, ipaddress_str,
+                    initialPortValue, finalPortValue);
+
+#else
             fprintf(nat_fp, "-A %s -o %s -p udp --sport %d:%d -j SNAT --to-source %s:%d-%d\n",MAPT_NAT_IPV4_POST_ROUTING_TABLE, get_current_wan_ifname(), initialPortValue, finalPortValue, ipaddress_str,
                     initialPortValue, finalPortValue);
+#endif
+
 #elif defined(NAT46_KERNEL_SUPPORT) || defined (FEATURE_SUPPORT_MAPT_NAT46)
 #if defined(_HUB4_PRODUCT_REQ_NO_DPORT_)
             fprintf(nat_fp, "-A %s -p tcp -m connlimit --connlimit-upto %d --connlimit-daddr -j SNAT --to-source %s:%d-%d\n", MAPT_NAT_IPV4_POST_ROUTING_TABLE, finalPortValue - initialPortValue + 1, ipaddress_str, initialPortValue,finalPortValue);
@@ -1319,9 +1335,15 @@ int do_mapt_rules_v4(FILE *nat_fp, FILE *filter_fp, FILE *mangle_fp)
             FIREWALL_DEBUG("MAPT Rule: Port range is initialPortValue=%u, finalPortValue=%u \n" COMMA initialPortValue COMMA finalPortValue);
         }
 #ifdef IVI_KERNEL_SUPPORT
-        fprintf(nat_fp, "-A %s -o %s -p icmp -j SNAT --to-source %s:%d-%d\n", MAPT_NAT_IPV4_POST_ROUTING_TABLE, get_current_wan_ifname(), ipaddress_str,initialPortValue, finalPortValue);
+#if defined(_PLATFORM_GENERICARM_)
+	fprintf(nat_fp, "-A %s -o %s -p icmp -j SNAT --to-source %s:%d-%d\n", MAPT_NAT_IPV4_POST_ROUTING_TABLE, current_wan_ifname, ipaddress_str,initialPortValue, finalPortValue);
+	fprintf(nat_fp, "-A %s -o %s -p tcp -j SNAT --to-source %s:%d-%d\n", MAPT_NAT_IPV4_POST_ROUTING_TABLE, current_wan_ifname, ipaddress_str, initialPortValue, finalPortValue);
+	fprintf(nat_fp, "-A %s -o %s -p udp -j SNAT --to-source %s:%d-%d\n", MAPT_NAT_IPV4_POST_ROUTING_TABLE, current_wan_ifname, ipaddress_str, initialPortValue,finalPortValue);
+#else
+	fprintf(nat_fp, "-A %s -o %s -p icmp -j SNAT --to-source %s:%d-%d\n", MAPT_NAT_IPV4_POST_ROUTING_TABLE, get_current_wan_ifname(), ipaddress_str,initialPortValue, finalPortValue);
         fprintf(nat_fp, "-A %s -o %s -p tcp -j SNAT --to-source %s:%d-%d\n", MAPT_NAT_IPV4_POST_ROUTING_TABLE, get_current_wan_ifname(), ipaddress_str, initialPortValue, finalPortValue);
         fprintf(nat_fp, "-A %s -o %s -p udp -j SNAT --to-source %s:%d-%d\n", MAPT_NAT_IPV4_POST_ROUTING_TABLE, get_current_wan_ifname(), ipaddress_str, initialPortValue,finalPortValue);
+#endif
 #endif //IVI_KERNEL_SUPPORT
     }
 
@@ -3178,7 +3200,7 @@ static int prepare_globals_from_configuration(void)
    fprintf(fp, "-A xlog_accept_wan2lan -j ACCEPT\n");
 
    fprintf(fp, "-A xlog_accept_wan2self -j ACCEPT\n");
-#if !(defined INTEL_PUMA7) && !(defined _COSA_BCM_ARM_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_COSA_QCA_ARM_)
+#if !(defined INTEL_PUMA7) && !(defined _COSA_BCM_ARM_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_COSA_QCA_ARM_) && !defined(_PLATFORM_GENERICARM_)
    fprintf(fp, "-A xlog_drop_wan2lan -j DROP\n");
 #endif
    fprintf(fp, "-A xlog_drop_wan2self -j DROP\n");
@@ -5475,7 +5497,7 @@ static int do_wan_nat_lan_clients(FILE *fp)
   }
 #endif
 
-#if (defined (_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)) && !defined (_HUB4_PRODUCT_REQ_)
+#if (defined (_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)) && !defined (_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_GENERICARM_)
   if(bEthWANEnable || isBridgeMode) // Check is required for TCHXB6 TCHXB7 CBR and not for HUB4
 #else
   if(bEthWANEnable)
@@ -6110,7 +6132,7 @@ int do_wan2self_attack(FILE *fp,char* wan_ip)
    {
       fprintf(fp, "-A SmurfAttack -p icmp -m icmp --icmp-type address-mask-request %s -j ULOG --ulog-prefix \"DoS Attack - Smurf Attack\" --ulog-cprange 50\n", logRateLimit);
    }
-#elif defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+#elif defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_PLATFORM_GENERICARM_)
    fprintf(fp, "-A SmurfAttack -p icmp -m icmp --icmp-type address-mask-request %s -j LOG --log-prefix \"DoS Attack - Smurf Attack\"\n", logRateLimit);
 #elif defined(_COSA_BCM_ARM_) && (defined(_CBR_PRODUCT_REQ_) || defined(_XB6_PRODUCT_REQ_))  
    fprintf(fp, "-A SmurfAttack -p icmp -m icmp --icmp-type address-mask-request %s -j NFLOG --nflog-group 2 --nflog-prefix \"DoS Attack - Smurf Attack\" --nflog-size 50\n", logRateLimit);
@@ -6130,7 +6152,7 @@ int do_wan2self_attack(FILE *fp,char* wan_ip)
    {
       fprintf(fp, "-A ICMPSmurfAttack -p icmp -m icmp --icmp-type timestamp-request %s -j ULOG --ulog-prefix \"DoS Attack - Smurf Attack\" --ulog-cprange 50\n", logRateLimit);
    }
-#elif defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+#elif defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_PLATFORM_GENERICARM_)
    fprintf(fp, "-A ICMPSmurfAttack -p icmp -m icmp --icmp-type timestamp-request %s -j LOG --log-prefix \"DoS Attack - Smurf Attack\"\n", logRateLimit);
 #elif defined(_COSA_BCM_ARM_) && (defined(_CBR_PRODUCT_REQ_) || defined(_XB6_PRODUCT_REQ_)) 
    fprintf(fp, "-A ICMPSmurfAttack -p icmp -m icmp --icmp-type timestamp-request %s -j NFLOG --nflog-group 2 --nflog-prefix \"DoS Attack - Smurf Attack\" --nflog-size 50\n", logRateLimit);
@@ -6152,7 +6174,7 @@ int do_wan2self_attack(FILE *fp,char* wan_ip)
    {
       fprintf(fp, "-A ICMPFlooding -p icmp %s -j ULOG --ulog-prefix \"DoS Attack - ICMP Flooding\" --ulog-cprange 50\n", logRateLimit);
    }
-#elif defined(_PLATFORM_RASPBERRYPI_) || defined (_PLATFORM_TURRIS_) ||  defined(_PLATFORM_BANANAPI_R4_)
+#elif defined(_PLATFORM_RASPBERRYPI_) || defined (_PLATFORM_TURRIS_) ||  defined(_PLATFORM_BANANAPI_R4_) || defined(_PLATFORM_GENERICARM_)
    fprintf(fp, "-A ICMPFlooding -p icmp %s -j LOG --log-prefix \"DoS Attack - ICMP Flooding\"\n", logRateLimit);
 #elif defined(_COSA_BCM_ARM_) && (defined(_CBR_PRODUCT_REQ_) || defined(_XB6_PRODUCT_REQ_)) 
    fprintf(fp, "-A ICMPFlooding -p icmp %s -j NFLOG --nflog-group 2 --nflog-prefix \"DoS Attack - ICMP Flooding\" --nflog-size 50\n", logRateLimit);
@@ -6174,7 +6196,7 @@ int do_wan2self_attack(FILE *fp,char* wan_ip)
    {
       fprintf(fp, "-A TCPSYNFlooding -p tcp --syn %s -j ULOG --ulog-prefix \"DoS Attack - TCP SYN Flooding\" --ulog-cprange 50\n", logRateLimit);
    }
-#elif defined(_PLATFORM_RASPBERRYPI_) || defined (_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+#elif defined(_PLATFORM_RASPBERRYPI_) || defined (_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_PLATFORM_GENERICARM_)
    fprintf(fp, "-A TCPSYNFlooding -p tcp --syn %s -j LOG --log-prefix \"DoS Attack - TCP SYN Flooding\"\n", logRateLimit);
 #elif defined(_COSA_BCM_ARM_) && (defined(_CBR_PRODUCT_REQ_) || defined(_XB6_PRODUCT_REQ_)) 
    fprintf(fp, "-A TCPSYNFlooding -p tcp --syn %s -j NFLOG --nflog-group 2 --nflog-prefix \"DoS Attack - TCP SYN Flooding\" --nflog-size 50\n", logRateLimit);
@@ -6198,7 +6220,7 @@ int do_wan2self_attack(FILE *fp,char* wan_ip)
        {
          fprintf(fp, "-A LANDAttack -s %s %s -j ULOG --ulog-prefix \"DoS Attack - LAND Attack\" --ulog-cprange 50\n", wan_ip, logRateLimit);
        }
-#elif defined(_PLATFORM_RASPBERRYPI_) || defined (_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+#elif defined(_PLATFORM_RASPBERRYPI_) || defined (_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_PLATFORM_GENERICARM_)
       fprintf(fp, "-A LANDAttack -s %s %s -j LOG --log-prefix \"DoS Attack - LAND Attack\"\n", wan_ip, logRateLimit);
 #elif defined(_COSA_BCM_ARM_) && (defined(_CBR_PRODUCT_REQ_) || defined(_XB6_PRODUCT_REQ_)) 
       fprintf(fp, "-A LANDAttack -s %s %s -j NFLOG --nflog-group 2 --nflog-prefix \"DoS Attack - LAND Attack\" --nflog-size 50\n", wan_ip, logRateLimit);
@@ -6561,7 +6583,7 @@ int do_remote_access_control(FILE *nat_fp, FILE *filter_fp, int family)
     if (family == AF_INET6)
     {
 #endif
-#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_)  && !defined(_PLATFORM_BANANAPI_R4_)
+#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_)  && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_PLATFORM_GENERICARM_)
 	   remote_access_set_proto(filter_fp, nat_fp, "80", srcaddr, family, ecm_wan_ifname);
        remote_access_set_proto(filter_fp, nat_fp, "443", srcaddr, family, ecm_wan_ifname);
 #endif
@@ -6833,7 +6855,7 @@ int do_remote_access_control(FILE *nat_fp, FILE *filter_fp, int family)
    }
 #endif
 
-#if defined(_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+#if defined(_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_PLATFORM_GENERICARM_)
     // RDKB-21814 
     // Drop only remote managment port(8080,8181) in bridge_mode 
     // because port 80, 443 will be used to access MSO page / local admin page.
@@ -7826,7 +7848,7 @@ InternetAccessPolicyNext3:
                snprintf(str, sizeof(str), 
                         "-A %s -p tcp -m tcp --dport 80 -m webstr --host \"%s\" -j %s",
                         rules_table, url + host_name_offset, block_site);
-#elif defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+#elif defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_PLATFORM_GENERICARM_)
                snprintf(str, sizeof(str), 
                         "-A %s -p tcp -m tcp --dport 80 -d \"%s\" -j %s",
                         rules_table, url + host_name_offset, block_site);
@@ -9289,7 +9311,7 @@ static int do_parcon_mgmt_site_keywd(FILE *fp, FILE *nat_fp, int iptype, FILE *c
         if (count < 0) count = 0;
         if (count > MAX_SYSCFG_ENTRIES) count = MAX_SYSCFG_ENTRIES;
 
-#if !defined(_COSA_BCM_MIPS_) && !defined(_CBR_PRODUCT_REQ_) && !defined(_COSA_BCM_ARM_) && !defined(_PLATFORM_TURRIS_) && !defined(_COSA_QCA_ARM_) && !defined(_PLATFORM_BANANAPI_R4_)
+#if !defined(_COSA_BCM_MIPS_) && !defined(_CBR_PRODUCT_REQ_) && !defined(_COSA_BCM_ARM_) && !defined(_PLATFORM_TURRIS_) && !defined(_COSA_QCA_ARM_) && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_PLATFORM_GENERICARM_)
         ruleIndex += do_parcon_mgmt_lan2wan_pc_site_appendrule(fp);
 #endif
 
@@ -11027,7 +11049,7 @@ static int prepare_multinet_postrouting_nat(FILE *nat_fp) {
 
 static void prepare_ipc_filter(FILE *filter_fp) {
                 FIREWALL_DEBUG("Entering prepare_ipc_filter\n"); 	  
-#if !defined (_COSA_BCM_ARM_) && !defined(INTEL_PUMA7) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_COSA_QCA_ARM_)
+#if !defined (_COSA_BCM_ARM_) && !defined(INTEL_PUMA7) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_COSA_QCA_ARM_) && !defined(_PLATFORM_GENERICARM_)
     // TODO: fix this hard coding
     fprintf(filter_fp, "-I OUTPUT -o %s -j ACCEPT\n", "l2sd0.500");
     fprintf(filter_fp, "-I INPUT -i %s -j ACCEPT\n", "l2sd0.500");
@@ -11038,7 +11060,7 @@ static void prepare_ipc_filter(FILE *filter_fp) {
 //zqiu<<
 #endif
 
-#if (defined (_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)) && !defined(_HUB4_PRODUCT_REQ_)
+#if (defined (_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)) && !defined(_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_GENERICARM_)
 #if defined (_RDKB_GLOBAL_PRODUCT_REQ_)
    if( 0 != strncmp( devicePartnerId, "sky-", 4 ) )
 #endif
@@ -11249,7 +11271,7 @@ static int prepare_multinet_filter_forward (FILE *filter_fp)
 #endif /*_HUB4_PRODUCT_REQ_*/
         //fprintf(filter_fp, "-A OUTPUT -o %s -j ACCEPT\n", net_resp);
 
-#if defined (INTEL_PUMA7) || ((defined (_COSA_BCM_ARM_) || defined (_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_COSA_QCA_ARM_)) && !defined(_CBR_PRODUCT_REQ_) && !defined(_HUB4_PRODUCT_REQ_))
+#if defined (INTEL_PUMA7) || ((defined (_COSA_BCM_ARM_) || defined (_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_COSA_QCA_ARM_)) && !defined(_CBR_PRODUCT_REQ_) && !defined(_HUB4_PRODUCT_REQ_)) || defined(_PLATFORM_GENERICARM_)
 #if defined (_RDKB_GLOBAL_PRODUCT_REQ_)
    if( 0 != strncmp( devicePartnerId, "sky-", 4 ) )
 #endif
@@ -11340,7 +11362,7 @@ static int prepare_multinet_filter_forward (FILE *filter_fp)
 
     fprintf(filter_fp, "-A INPUT -i brebhaul -d 169.254.85.0/24 -j ACCEPT\n");
     fprintf(filter_fp, "-A INPUT -i brebhaul -m pkttype ! --pkt-type unicast -j ACCEPT\n");
-#elif defined (_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+#elif defined (_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_PLATFORM_GENERICARM_)
     fprintf(filter_fp, "-A INPUT -i wifi2 -d 169.254.0.0/24 -j ACCEPT\n");
     fprintf(filter_fp, "-A INPUT -i wifi2 -m pkttype ! --pkt-type unicast -j ACCEPT\n");
     fprintf(filter_fp, "-A INPUT -i wifi3 -d 169.254.1.0/24 -j ACCEPT\n");
@@ -11383,7 +11405,7 @@ static int prepare_multinet_filter_forward (FILE *filter_fp)
     fprintf(filter_fp, "-A INPUT -i br403 -s 192.168.245.0/24 -p tcp -m tcp --dport 8883 -j ACCEPT\n");
 #endif
 
-#if defined (INTEL_PUMA7) || ((defined (_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_COSA_QCA_ARM_)) && !defined(_CBR_PRODUCT_REQ_) && !defined(_HUB4_PRODUCT_REQ_)) || defined (_CBR2_PRODUCT_REQ_)
+#if defined (INTEL_PUMA7) || ((defined (_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_COSA_QCA_ARM_)) && !defined(_CBR_PRODUCT_REQ_) && !defined(_HUB4_PRODUCT_REQ_)) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_GENERICARM_)
     fprintf(filter_fp, "-A INPUT -i br403 -d 192.168.245.0/24 -j ACCEPT\n");
     fprintf(filter_fp, "-A INPUT -i br403 -m pkttype ! --pkt-type unicast -j ACCEPT\n");
 #endif
@@ -12186,9 +12208,9 @@ static int prepare_subtables(FILE *raw_fp, FILE *mangle_fp, FILE *nat_fp, FILE *
 #endif
 
 #if WAN_FAILOVER_SUPPORTED
-#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_PLATFORM_GENERICARM_)
    redirect_dns_to_extender(nat_fp,AF_INET);
-#endif //_PLATFORM_RASPBERRYPI_ && _PLATFORM_BANANAPI_R4_
+#endif //_PLATFORM_RASPBERRYPI_ && _PLATFORM_BANANAPI_R4_ && _PLATFORM_GENERICARM_
 #endif 
 
 #if defined(_WNXL11BWL_PRODUCT_REQ_) 
@@ -12361,7 +12383,7 @@ static int prepare_subtables(FILE *raw_fp, FILE *mangle_fp, FILE *nat_fp, FILE *
    //Avoid blocking packets at the Intel NIL layer
    fprintf(filter_fp, "-A FORWARD -i a-mux -j ACCEPT\n");
 #endif
-#if defined(INTEL_PUMA7) || defined (_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_COSA_QCA_ARM_)
+#if defined(INTEL_PUMA7) || defined (_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_COSA_QCA_ARM_) || defined(_PLATFORM_GENERICARM_)
    fprintf(filter_fp, "-A INPUT -i host0 -s 192.168.147.0/255.255.255.0 -j ACCEPT\n");
    fprintf(filter_fp, "-A OUTPUT -o host0 -d 192.168.147.0/255.255.255.0 -j ACCEPT\n");
 #endif
@@ -12371,7 +12393,7 @@ static int prepare_subtables(FILE *raw_fp, FILE *mangle_fp, FILE *nat_fp, FILE *
    fprintf(filter_fp, "-A OUTPUT -o lo -p tcp -m tcp --sport 49152:49153 -j ACCEPT\n");
    fprintf(filter_fp, "-A OUTPUT ! -o brlan0 -p tcp -m tcp --sport 49152:49153 -j DROP\n");
    /* For EasyMesh Controller Communication */
-#if defined(_PLATFORM_BANANAPI_R4_)
+#if defined(_PLATFORM_BANANAPI_R4_) || defined(_PLATFORM_GENERICARM_)
    fprintf(filter_fp, "-I OUTPUT -o %s -p tcp --sport 49153 -j ACCEPT\n",get_current_wan_ifname());
 #endif
    char tr69_enabled[20];
@@ -12560,9 +12582,13 @@ static int prepare_subtables(FILE *raw_fp, FILE *mangle_fp, FILE *nat_fp, FILE *
    fprintf(filter_fp, "-A INPUT -p udp -m udp --match multiport --dports 10161,10163 -j SNMP_FILTER\n");
 
    //DROP incoming New NTP packets on erouter interface
+#if defined(_PLATFORM_GENERICARM_)
+   fprintf(filter_fp, "-A INPUT -i %s -m state --state ESTABLISHED,RELATED -p udp --dport 123 -j ACCEPT \n", current_wan_ifname);
+   fprintf(filter_fp, "-A INPUT -i %s  -m state --state NEW -p udp --dport 123 -j DROP \n",current_wan_ifname);
+#else
    fprintf(filter_fp, "-A INPUT -i %s -m state --state ESTABLISHED,RELATED -p udp --dport 123 -j ACCEPT \n", get_current_wan_ifname());
    fprintf(filter_fp, "-A INPUT -i %s  -m state --state NEW -p udp --dport 123 -j DROP \n",get_current_wan_ifname());
-
+#endif
    /* RDKB-57182 Blocking brlan0 ports 80,443 for interfaces other than lan */
    fprintf(filter_fp, "-A INPUT -i brlan0 -p tcp -m multiport --dports 80,443 ! -d %s -j DROP\n", lan_ipaddr);
 
@@ -12576,7 +12602,7 @@ static int prepare_subtables(FILE *raw_fp, FILE *mangle_fp, FILE *nat_fp, FILE *
 #if !defined(_COSA_INTEL_XB3_ARM_)
    filterPortMap(filter_fp);
 #endif
-#if defined(_COSA_BCM_ARM_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_)
+#if defined(_COSA_BCM_ARM_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_PLATFORM_GENERICARM_)
    fprintf(filter_fp, "-A INPUT -s 172.31.255.40/32 -p tcp -m tcp --dport 9000 -j ACCEPT\n");
    fprintf(filter_fp, "-A INPUT -s 172.31.255.40/32 -p udp -m udp --dport 9000 -j ACCEPT\n");
    fprintf(filter_fp, "-A INPUT -p tcp -m tcp --dport 9000 -j DROP\n");
@@ -12624,7 +12650,7 @@ static int prepare_subtables(FILE *raw_fp, FILE *mangle_fp, FILE *nat_fp, FILE *
        fprintf(filter_fp, "-A INPUT -p tcp -i %s --match multiport --dport 80,443 -j ACCEPT\n",cmdiag_ifname);  
    }
 
-   #if defined(_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+   #if defined(_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_PLATFORM_GENERICARM_)
        #if !defined(_CBR_PRODUCT_REQ_) && !defined (_BWG_PRODUCT_REQ_) && !defined (_CBR2_PRODUCT_REQ_)
            fprintf(filter_fp, "-A FORWARD -i %s -o privbr -p tcp -m multiport --dport 22,23,80,443 -j DROP\n",XHS_IF_NAME);
            fprintf(filter_fp, "-A FORWARD -i %s -o privbr -p tcp -m multiport --dport 22,23,80,443 -j DROP\n",LNF_IF_NAME);
@@ -12833,7 +12859,7 @@ static int prepare_subtables(FILE *raw_fp, FILE *mangle_fp, FILE *nat_fp, FILE *
    } else {
        fprintf(filter_fp, "-A SSH_FILTER -j ACCEPT\n");
    } */   
-#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_)
+#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_PLATFORM_GENERICARM_)
    do_ssh_IpAccessTable(filter_fp, "22", AF_INET, ecm_wan_ifname);
 #else
     fprintf(filter_fp, "-A SSH_FILTER -j ACCEPT\n");
@@ -12900,13 +12926,13 @@ static int prepare_subtables(FILE *raw_fp, FILE *mangle_fp, FILE *nat_fp, FILE *
    prepare_multinet_filter_forward(filter_fp);
    fprintf(filter_fp, "-A FORWARD -j xlog_drop_wan2lan\n");
 
-#if !defined(_COSA_BCM_ARM_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_)
+#if !defined(_COSA_BCM_ARM_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_PLATFORM_GENERICARM_)
    fprintf(filter_fp, "-I FORWARD 3 -i %s -o l2sd0.4090 -j ACCEPT\n", current_wan_ifname);
    fprintf(filter_fp, "-I FORWARD 2 -i br403 -o %s -j ACCEPT\n", current_wan_ifname);
    fprintf(filter_fp, "-I FORWARD 3 -i %s -o br403 -j ACCEPT\n", current_wan_ifname);
 #endif
 
-#if defined (INTEL_PUMA7) || ((defined (_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_COSA_QCA_ARM_)) && !defined(_CBR_PRODUCT_REQ_) && !defined(_HUB4_PRODUCT_REQ_)) || defined (_CBR2_PRODUCT_REQ_)
+#if defined (INTEL_PUMA7) || ((defined (_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_COSA_QCA_ARM_)) && !defined(_CBR_PRODUCT_REQ_) && !defined(_HUB4_PRODUCT_REQ_)) || defined (_CBR2_PRODUCT_REQ_) || defined(_PLATFORM_GENERICARM_)
 #if defined (_RDKB_GLOBAL_PRODUCT_REQ_)
    if( 0 != strncmp( devicePartnerId, "sky-", 4 ) )
 #endif
@@ -12925,7 +12951,7 @@ static int prepare_subtables(FILE *raw_fp, FILE *mangle_fp, FILE *nat_fp, FILE *
    fprintf(filter_fp, "-I FORWARD -m conntrack --ctdir reply -m connbytes --connbytes 0:15 --connbytes-dir reply --connbytes-mode packets -j GWMETA --dis-pp\n");
 #endif
 
-#if (defined(_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_))
+#if (defined(_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)) || defined(_PLATFORM_GENERICARM_)
    fprintf(filter_fp, "-I FORWARD -d 192.168.100.1/32 -i %s -j DROP\n", lan_ifname);
    fprintf(filter_fp, "-I FORWARD -d 172.31.255.0/24 -j DROP\n");
    fprintf(filter_fp, "-I INPUT -d 172.31.255.0/24 -i %s -j DROP\n", lan_ifname);
@@ -12965,7 +12991,7 @@ static int prepare_subtables(FILE *raw_fp, FILE *mangle_fp, FILE *nat_fp, FILE *
       //zqiu: R5337
       //do_lan2wan_IoT_Allow(filter_fp);
       do_wan2lan_IoT_Allow(filter_fp);
-#if defined (INTEL_PUMA7) || ((defined (_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_COSA_QCA_ARM_)) && !defined(_CBR_PRODUCT_REQ_)) // ARRIS XB6 ATOM, TCXB6
+#if defined (INTEL_PUMA7) || ((defined (_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_COSA_QCA_ARM_)) && !defined(_CBR_PRODUCT_REQ_)) || defined(_PLATFORM_GENERICARM_)// ARRIS XB6 ATOM, TCXB6
       // Block forwarding between bridges.
       fprintf(filter_fp, "-A FORWARD -i %s -o %s -j DROP\n", lan_ifname, iot_ifName);
       fprintf(filter_fp, "-A FORWARD -i %s -o %s -j DROP\n", XHS_IF_NAME, iot_ifName);
@@ -13462,7 +13488,7 @@ int do_block_ports(FILE *filter_fp)
 
    fprintf(filter_fp, "-A INPUT ! -i brlan0 -p tcp -m tcp --dport 49152:49153 -j DROP\n");
    /* For EasyMesh Controller Communication */
-#if defined(_PLATFORM_BANANAPI_R4_)
+#if defined(_PLATFORM_BANANAPI_R4_) || defined(_PLATFORM_GENERICARM_)
    fprintf(filter_fp, "-I INPUT -i %s -p tcp --dport 49153 -j ACCEPT\n", get_current_wan_ifname());
    fprintf(filter_fp, "-I INPUT -i %s -p tcp --dport 8888 -j ACCEPT\n", get_current_wan_ifname());
 #endif
@@ -13729,7 +13755,7 @@ void  proxy_dns(FILE *nat_fp,int family)
 #endif
 
 #ifdef WAN_FAILOVER_SUPPORTED
-#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
+#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_PLATFORM_GENERICARM_)
 void  redirect_dns_to_extender(FILE *nat_fp,int family)
 {
    FIREWALL_DEBUG("Entering redirect_dns_to_extender,current_wan_ifname is %s , default wan is %s\n" COMMA current_wan_ifname COMMA default_wan_ifname);
@@ -14290,12 +14316,19 @@ static int prepare_disabled_ipv4_firewall(FILE *raw_fp, FILE *mangle_fp, FILE *n
    fprintf(filter_fp, "-A SNMPDROPLOG -j DROP\n");
 
    //DROP incoming  NTP packets on erouter interface
+#if defined(_PLATFORM_GENERICARM_)
+   fprintf(filter_fp, "-A INPUT -i %s -m state --state ESTABLISHED,RELATED -p udp --dport 123 -j ACCEPT \n", current_wan_ifname);
+   fprintf(filter_fp, "-A INPUT -i %s  -m state --state NEW -p udp --dport 123 -j DROP \n",current_wan_ifname);
+#else
    fprintf(filter_fp, "-A INPUT -i %s -m state --state ESTABLISHED,RELATED -p udp --dport 123 -j ACCEPT \n", get_current_wan_ifname());
    fprintf(filter_fp, "-A INPUT -i %s  -m state --state NEW -p udp --dport 123 -j DROP \n",get_current_wan_ifname());
-
+#endif
    //DROP incoming 21515 port on erouter interface
+#if defined(_PLATFORM_GENERICARM_)
+   fprintf(filter_fp, "-A INPUT -i %s -p tcp -m tcp --dport 21515 -j DROP\n",current_wan_ifname);
+#else
    fprintf(filter_fp, "-A INPUT -i %s -p tcp -m tcp --dport 21515 -j DROP\n",get_current_wan_ifname());
-
+#endif
    // Video Analytics Firewall rule to allow port 58081 only from LAN interface
    do_OpenVideoAnalyticsPort (filter_fp);
 
@@ -14303,7 +14336,7 @@ static int prepare_disabled_ipv4_firewall(FILE *raw_fp, FILE *mangle_fp, FILE *n
    filterPortMap(filter_fp);
 #endif
 
-#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_)
+#if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_PLATFORM_GENERICARM_)
    do_ssh_IpAccessTable(filter_fp, "22", AF_INET, ecm_wan_ifname);
 #else
    fprintf(filter_fp, "-A SSH_FILTER -j ACCEPT\n");
@@ -14398,7 +14431,7 @@ static int prepare_disabled_ipv4_firewall(FILE *raw_fp, FILE *mangle_fp, FILE *n
    {
        fprintf(filter_fp, "-A INPUT -p tcp -i %s --match multiport --dport 80,443 -j ACCEPT\n",cmdiag_ifname);  
    }
-   #if defined(_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
+   #if defined(_COSA_BCM_ARM_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_) || defined(_PLATFORM_GENERICARM_)
         #if !defined(_CBR_PRODUCT_REQ_) && !defined (_BWG_PRODUCT_REQ_) && !defined (_CBR2_PRODUCT_REQ_)
            fprintf(filter_fp, "-A FORWARD -i %s -o privbr -p tcp -m multiport --dport 22,23,80,443 -j DROP\n",XHS_IF_NAME);
            fprintf(filter_fp, "-A FORWARD -i %s -o privbr -p tcp -m multiport --dport 22,23,80,443 -j DROP\n",LNF_IF_NAME);
@@ -15192,6 +15225,11 @@ static int service_start ()
        /* Apply Mac Filtering rules */
        v_secure_system("/bin/sh -c /tmp/mac_filter.sh");
    #endif
+   #ifdef _PLATFORM_GENERICARM__
+       /* Apply Mac Filtering rules */
+       v_secure_system("/bin/sh -c /tmp/mac_filter.sh");
+   #endif
+
 
   #if 0
    /* RFC REFRESH for dynamic whitelisting of IPs */

--- a/source/igd/src/igd_device_root.c
+++ b/source/igd/src/igd_device_root.c
@@ -80,9 +80,11 @@
 #include "pal_kernel.h"
 #include "igd_platform_independent_inf.h"
 #include "igd_utility.h"
-
+#if defined(_PLATFORM_GENERICARM_)
+#define DEFAULT_WEB_DIR "/var/volatile/IGD"
+#else
 #define DEFAULT_WEB_DIR "/var/IGD"
-
+#endif
 #define DEFAULT_ADVR_EXPIRE 1800
 #define VERSION_MAJOR 		1
 #define VERSION_MINOR 		0

--- a/source/scripts/init/service.d/lan_handler.sh
+++ b/source/scripts/init/service.d/lan_handler.sh
@@ -54,7 +54,12 @@ SERVICE_NAME="lan_handler"
 
 POSTD_START_FILE="/tmp/.postd_started"
 
+if [ "$BOX_TYPE" = "genericarm" ]; then
+	RPI_SPECIFIC="rpi"
+else
 RPI_SPECIFIC=$BOX_TYPE
+fi
+
 #args: router IP, subnet mask
 ap_addr() {
     if [ "$2" ]; then
@@ -129,6 +134,19 @@ if [ "$1" = "lan-stop" ] && [ "$2" = "NULL" ] ; then
     t2CountNotify "RF_ERROR_LAN_stop"
 fi
 #echo "lan_handler called with $1 $2" > /dev/console
+
+if [ "$BOX_TYPE" = "genericarm" ]; then
+# Used by brlan0_check.sh to workaround LAN issue
+if [ "$1" = "lan-start" ]; then
+    touch /tmp/utopia-lan-started
+fi
+if [ "$1" = "lan-stop" ]; then
+    rm /tmp/utopia-lan-started || :
+fi
+if [ "$1" = "ipv4_4-status" ] && [ "$2" = "up" ]; then
+    touch /tmp/utopia-ipv4-4-up
+fi
+fi
 
 case "$1" in
    ${SERVICE_NAME}-start)
@@ -308,6 +326,25 @@ case "$1" in
             echo "Setting up brlan10 for HOME_LAN_ISOLATION"
             sysevent set multinet-up 9
         fi
+        if [ "${BOX_TYPE}" = "genericarm" ]; then
+	        # --------------------------------------------------------------------
+        # RPi specific change begin
+        # --------------------------------------------------------------------
+
+        PHY_BRIDGE_IFNAME=`syscfg get lan_ifname`
+        PHY_ETH_IFNAMES=`syscfg get lan_ethernet_physical_ifnames`
+        IFS=' ' read -r -a PHY_ETH_IFNAME_ARRAY <<< "$PHY_ETH_IFNAMES"
+        for PHY_ETH_IFNAME in "${PHY_ETH_IFNAME_ARRAY[@]}"
+        do
+            echo "LAN HANDLER : PHY_ETH_IFNAME = $PHY_ETH_IFNAME"
+            ifconfig $PHY_ETH_IFNAME up
+            brctl addif $PHY_BRIDGE_IFNAME $PHY_ETH_IFNAME
+        done
+
+        # --------------------------------------------------------------------
+        # RPi specific change end
+        # --------------------------------------------------------------------
+	fi
 
         echo_t "LAN HANDLER : Triggering RDKB_FIREWALL_RESTART after nfqhandler"
 	t2CountNotify "RF_INFO_RDKB_FIREWALL_RESTART"
@@ -356,7 +393,7 @@ case "$1" in
 		echo_t "THE INSTANT=$INST"
 		echo_t "THE INSTANT=$INST"
         #(use a simpler test than this -- but Hacky, since it assumes everything we want is not XB3!!)if [ "$BOX_TYPE" = "TCCBR" ] || [ "$BOX_TYPE" = "XB6" -a "$MANUFACTURE" = "Technicolor" ] || [ "$BOX_TYPE" = "XB7" -a "$MANUFACTURE" = "Technicolor" ] ; then
-	if ( [ "$BOX_TYPE" != "XB3" ] && ( [ "$MANUFACTURE" = "Technicolor" ] || [ "$MANUFACTURE" = "Sercomm" ] ) )  || [ "$BOX_TYPE" = "rpi" ] || [ "$BOX_TYPE" = "bpi" ]; then
+	if ( [ "$BOX_TYPE" != "XB3" ] && ( [ "$MANUFACTURE" = "Technicolor" ] || [ "$MANUFACTURE" = "Sercomm" ] ) )  || [ "$BOX_TYPE" = "rpi" ] || [ "$BOX_TYPE" = "bpi" ] || [ "$BOX_TYPE" = "genericarm" ]; then
                 	COUNTER=1
 			while [ $COUNTER -lt 10 ]; do
 				echo_t "RDKB_SYSTEM_BOOT_UP_LOG : INST returned null , retrying $COUNTER"

--- a/source/scripts/init/service.d/service_dhcp_server.sh
+++ b/source/scripts/init/service.d/service_dhcp_server.sh
@@ -59,7 +59,11 @@ UTOPIA_PATH="/etc/utopia/service.d"
 SERVICE_NAME="dhcp_server"
 
 #DHCP_CONF=/etc/dnsmasq.conf
+if ([ "$BOX_TYPE" = "genericarm" ]) ;then
+	DHCP_CONF=/var/volatile/dnsmasq.conf
+else
 DHCP_CONF=/var/dnsmasq.conf
+fi
 RESOLV_CONF=/etc/resolv.conf
 BIN=dnsmasq
 SERVER=${BIN}
@@ -451,7 +455,7 @@ dhcp_server_start ()
         return 1
     fi
   
-  if [ "$BOX_TYPE" != "rpi" ] && [ "$BOX_TYPE" != "bpi" ] && [ "$BOX_TYPE" != "turris" ]; then
+  if [ "$BOX_TYPE" != "rpi" ] && [ "$BOX_TYPE" != "bpi" ] && [ "$BOX_TYPE" != "turris" ] && [ "$BOX_TYPE" != "genericarm" ]; then
    DHCP_STATE=`sysevent get lan_status-dhcp`
    #if [ "started" != "$CURRENT_LAN_STATE" ] ; then
    if [ "started" != "$DHCP_STATE" ] ; then
@@ -591,7 +595,7 @@ dhcp_server_start ()
    if [ $? -eq 0 ]; then
    	echo_t "$SERVER process started successfully"
    else
-   	if [ "$BOX_TYPE" = "XB6" ] || [ "$BOX_TYPE" = "PUMA7_CGP" ] || [ "$BOX_TYPE" = "rpi" ] || [ "$BOX_TYPE" = "bpi" ] || [ "$BOX_TYPE" = "turris" ] ; then
+	   if [ "$BOX_TYPE" = "XB6" ] || [ "$BOX_TYPE" = "PUMA7_CGP" ] || [ "$BOX_TYPE" = "rpi" ] || [ "$BOX_TYPE" = "bpi" ] || [ "$BOX_TYPE" = "turris" ] || [ "$BOX_TYPE" = "genericarm" ]; then
    
         	COUNTER=0
         	while [ $COUNTER -lt 5 ]; do

--- a/source/scripts/init/service.d/service_dhcp_server/dhcp_server_functions.sh
+++ b/source/scripts/init/service.d/service_dhcp_server/dhcp_server_functions.sh
@@ -1132,7 +1132,7 @@ fi
       fi
    fi
   
-   if [ "$BOX_TYPE" = "rpi" ] || [ "$BOX_TYPE" = "bpi" ] || [ "$BOX_TYPE" = "turris" ]; then
+   if [ "$BOX_TYPE" = "rpi" ] || [ "$BOX_TYPE" = "bpi" ] || [ "$BOX_TYPE" = "turris" ] || [ "$BOX_TYPE" = "genericarm" ]; then
 	   LAN_STATUS=`sysevent get lan-status`
 	   BRIDGE_MODE=`syscfg get bridge_mode`
 	   if [ "$LAN_STATUS" = "stopped" ] && [ $BRIDGE_MODE == 0 ]; then                

--- a/source/scripts/init/service.d/service_dhcpv6_client.sh
+++ b/source/scripts/init/service.d/service_dhcpv6_client.sh
@@ -369,7 +369,9 @@ call_back_remove_prefix ()
 #-------------------------------------------------------------------------------------------
 
 service_init 
-
+if [ "$BOX_TYPE" = "genericarm" ]; then
+	logger -t "utopia_${SERVICE_NAME}" "Called $1 parent $PPID"
+fi
 case "$1" in
    "${SERVICE_NAME}-start")
       service_start
@@ -405,6 +407,10 @@ case "$1" in
       else
 	echo "$SELF: unknown event ($EVENT) or unknow DHCP call back ($REASON)" >> $LOG
 	echo "Usage: $SERVICE_NAME [ ${SERVICE_NAME}-start | ${SERVICE_NAME}-stop | ${SERVICE_NAME}-restart]" > /dev/console
+	if [ "$BOX_TYPE" = "genericarm" ]; then
+		logger -t "utopia_${SERVICE_NAME}" "Called $1 parent $PPID"
+        fi
+
 	exit 3
       fi
       ;;

--- a/source/scripts/init/service.d/service_igd.sh
+++ b/source/scripts/init/service.d/service_igd.sh
@@ -46,7 +46,11 @@ SELF_NAME="`basename $0`"
 
 #IGD=/usr/sbin/IGD
 IGD=IGD
-IGD_TMP_DIR="/var/IGD"
+if ([ "$BOX_TYPE" = "genericarm" ]) ;then
+	IGD_TMP_DIR="/var/volatile/IGD"
+else
+	IGD_TMP_DIR="/var/IGD"
+fi
 UPNP_TMP=/var/tmp/upnp.ttl
 PRIVATE_LAN_IF="brlan0"
 

--- a/source/scripts/init/service.d/service_ipv4.sh
+++ b/source/scripts/init/service.d/service_ipv4.sh
@@ -129,7 +129,7 @@ handle_l2_status () {
                 fi
                fi
             fi
-            if [ "$BOX_TYPE" = "rpi" ] || [ "$BOX_TYPE" = "bpi" ]; then
+            if [ "$BOX_TYPE" = "rpi" ] || [ "$BOX_TYPE" = "bpi" ] || [ "$BOX_TYPE" = "genericarm" ]; then
                  LAN_STATUS=`sysevent get lan-status`
                  if [ "$LAN_STATUS" = "stopped" ]; then
                       echo_t "service_ipv4 : Starting lan-status"

--- a/source/scripts/init/system/utopia_init.sh
+++ b/source/scripts/init/system/utopia_init.sh
@@ -790,7 +790,7 @@ else
       fi
 fi
 
-if [ "$MODEL_NUM" = "DPC3939B" ] || [ "$MODEL_NUM" = "DPC3941B" ]; then
+if [ "$MODEL_NUM" = "DPC3939B" ] || [ "$MODEL_NUM" = "DPC3941B" ] || [ "${BOX_TYPE}" = "genericarm" ]; then
     if [ -f /nvram/restore_reboot ];then
 	syscfg set X_RDKCENTRAL-COM_LastRebootReason "restore-reboot"
 	syscfg set X_RDKCENTRAL-COM_LastRebootCounter "1"
@@ -859,7 +859,7 @@ syscfg set ntp_status 2
 echo_t "[utopia][init] setting Multicast MAC before any switch configs"
 $UTOPIA_PATH/service_multinet_exec set_multicast_mac &
 
-if [ "$MODEL_NUM" = "DPC3939B" ] || [ "$MODEL_NUM" = "DPC3941B" ]; then
+if [ "$MODEL_NUM" = "DPC3939B" ] || [ "$MODEL_NUM" = "DPC3941B" ] || [ "${BOX_TYPE}" = "genericarm" ]; then
 	echo_t "[utopia][init] started dropbear process"
 	/etc/utopia/service.d/service_sshd.sh sshd-start &
 fi

--- a/source/service_dhcp/dhcp_server_functions.c
+++ b/source/service_dhcp/dhcp_server_functions.c
@@ -59,7 +59,11 @@
 #define STATIC_URLS_FILE        "/etc/static_urls"
 #define STATIC_DNS_URLS_FILE    "/etc/static_dns_urls"
 #define NETWORK_RES_FILE      	"/var/tmp/networkresponse.txt"
+#if defined(_PLATFORM_GENERICARM_)
+#define DHCP_CONF               "/var/volatile/dnsmasq.conf"
+#else
 #define DHCP_CONF               "/var/dnsmasq.conf"
+#endif
 #define DHCP_LEASE_FILE         "/nvram/dnsmasq.leases"
 #define DEFAULT_RESOLV_CONF     "/var/default/resolv.conf"
 #define DEFAULT_CONF_DIR      	"/var/default"

--- a/source/service_dhcp/service_dhcp_server.c
+++ b/source/service_dhcp/service_dhcp_server.c
@@ -41,7 +41,11 @@
 #define SERVER      "dnsmasq"
 #define PMON        "/etc/utopia/service.d/pmon.sh"
 #define RESOLV_CONF "/etc/resolv.conf"
+#if defined(_PLATFORM_GENERICARM_)
+#define DHCP_CONF   "/var/volatile/dnsmasq.conf"
+#else
 #define DHCP_CONF   "/var/dnsmasq.conf"
+#endif
 #define PID_FILE    "/var/run/dnsmasq.pid"
 #define RPC_CLIENT	"/usr/bin/rpcclient"
 #define XHS_IF_NAME "brlan1"

--- a/source/service_wan/service_wan.c
+++ b/source/service_wan/service_wan.c
@@ -1508,7 +1508,7 @@ STATIC int wan_iface_up(struct serv_wan *sw)
 STATIC int wan_iface_down(struct serv_wan *sw)
 {
     int err = 0;
-#if !defined(_PLATFORM_RASPBERRYPI_)  && !defined(_PLATFORM_BANANAPI_R4_)
+#if !defined(_PLATFORM_RASPBERRYPI_)  && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_PLATFORM_GENERICARM_)
     err = v_secure_system("ip -4 link set %s down", sw->ifname);
 #endif
 #if PUMA6_OR_NEWER_SOC_TYPE
@@ -1742,7 +1742,7 @@ STATIC int wan_addr_set(struct serv_wan *sw)
     	if(strcmp(mischandler_ready,"true") == 0)
     	{
     		//only for first time
-    #if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_)  && !defined(_PLATFORM_BANANAPI_R4_)
+    #if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_TURRIS_)  && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_PLATFORM_GENERICARM_)
     		fprintf(stderr, "[%s] ready is set from misc handler. Doing gw_lan_refresh\n", PROG_NAME);
             #if defined (_XB6_PRODUCT_REQ_) && defined (_COSA_BCM_ARM_)
                 v_secure_system("firewall");


### PR DESCRIPTION
Reason For Change: Upstreamed Generic ARM specific changes into common code to avoid maintaining platform patches.
Test Procedure: No utopia patches under meta-rdk-bsp-arm, should boot-up and should work as expected.
Risks: None