### PR TITLE
fix: CS4 marking is not present on the WiFi interface (wl0) — the WiFi driver or WMM  (device 40:75:C3:3B:7D:44)

### DIFF
--- a/fixes/2026-05-12/4075c33b7d44-76a3d3d2-2e2.json
+++ b/fixes/2026-05-12/4075c33b7d44-76a3d3d2-2e2.json
@@ -1,0 +1,16 @@
+{
+  "device_mac": "40:75:C3:3B:7D:44",
+  "job_id": "76a3d3d2-2e2",
+  "timestamp": "2026-05-12T19:56:06Z",
+  "root_cause": "CS4 marking is not present on the WiFi interface (wl0) \u2014 the WiFi driver or WMM layer is likely stripping/downgrading DSCP before packets enter the bridge, so CS4 never reaches the WAN",
+  "severity": "high",
+  "fix_commands": [
+    "Verify the client is actually sending CS4-marked packets (capture at the client itself)",
+    "Check WiFi driver WMM/DSCP mapping \u2014 many Memory WiFi drivers remap DSCP on ingress; look for 'wmm_dscp' or 'dscp_prio_map' parameters",
+    "Inspect mangle POSTROUTING and prerouting_qos for any --set-dscp or DSCP 0x00 rules",
+    "Validate with: tcpdump -i erouter0 -v 'ip[1] & 0xfc == 0x80' -c 10"
+  ],
+  "validation_commands": [],
+  "rollback_commands": [],
+  "fix_succeeded": false
+}

--- a/fixes/2026-05-12/4075c33b7d44-fix.sh
+++ b/fixes/2026-05-12/4075c33b7d44-fix.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Firewall fix for device 40:75:C3:3B:7D:44
+# Root cause: CS4 marking is not present on the WiFi interface (wl0) — the WiFi driver or WMM layer is likely stripping/downgrading DSCP before packets enter the bridge, so CS4 never reaches the WAN
+# Generated: 2026-05-12 19:56:06 UTC
+# Job ID: 76a3d3d2-2e2
+
+Verify the client is actually sending CS4-marked packets (capture at the client itself)
+Check WiFi driver WMM/DSCP mapping — many Memory WiFi drivers remap DSCP on ingress; look for 'wmm_dscp' or 'dscp_prio_map' parameters
+Inspect mangle POSTROUTING and prerouting_qos for any --set-dscp or DSCP 0x00 rules
+Validate with: tcpdump -i erouter0 -v 'ip[1] & 0xfc == 0x80' -c 10


### PR DESCRIPTION
## Device Fix: 40:75:C3:3B:7D:44
**Job ID:** `76a3d3d2-2e2`
**Severity:** high
**Fix Status:** not_applied

### Root Cause
CS4 marking is not present on the WiFi interface (wl0) — the WiFi driver or WMM layer is likely stripping/downgrading DSCP before packets enter the bridge, so CS4 never reaches the WAN

### Findings
- **high**: No CS4 packets observed on wl0 WiFi interface
- **medium**: prerouting_qos subchain not yet inspected — could contain DSCP rewrite rules
- **info**: bridge-nf-call-iptables=0 means bridged frames skip iptables mangle

### Applied Fix
- `Verify the client is actually sending CS4-marked packets (capture at the client itself)`
- `Check WiFi driver WMM/DSCP mapping — many Memory WiFi drivers remap DSCP on ingress; look for 'wmm_dscp' or 'dscp_prio_map' parameters`
- `Inspect mangle POSTROUTING and prerouting_qos for any --set-dscp or DSCP 0x00 rules`
- `Validate with: tcpdump -i erouter0 -v 'ip[1] & 0xfc == 0x80' -c 10`