### PR TITLE
RDKCOM-5586: RDKBDEV-3442 DNS Port 53 found to be open on non-relevant interfaces in CM

### DIFF
--- a/source/scripts/init/service.d/service_dhcp_server/dhcp_server_functions.sh
+++ b/source/scripts/init/service.d/service_dhcp_server/dhcp_server_functions.sh
@@ -1077,6 +1077,7 @@ fi
    fi
 
    #echo "interface=$LAN_IFNAME" >> $LOCAL_DHCP_CONF
+   echo "bind-dynamic" >> $LOCAL_DHCP_CONF
    echo "expand-hosts" >> $LOCAL_DHCP_CONF
    echo "address=/.c.f.ip6.arpa/" >> $LOCAL_DHCP_CONF
 


### PR DESCRIPTION
Reason for change: When bind-dynamic option is enabled in dnsmasq.conf, the DNS ports were dynamically bound to the active interface IPs. As a result, port 53 is no longer observed as open on non-relevant interfaces.
Risks: Low
Signed-off-by: Aiswarya Prasad <aprasad@maxlinear.com>