### PR TITLE
LTE-2904 : Facing SSH failures while accessing XLE after Gateway restore

### DIFF
--- a/source/scripts/init/c_registration/15_ssh_server.c
+++ b/source/scripts/init/c_registration/15_ssh_server.c
@@ -52,7 +52,7 @@ const char* SERVICE_CUSTOM_EVENTS[] = {
                                         "wan-status|/etc/utopia/service.d/service_sshd.sh",
 #endif
 #if defined(_WNXL11BWL_PRODUCT_REQ_)
-                                        "remote_ssh_server_ip|/etc/utopia/service.d/service_sshd.sh",
+                                        "mesh_wan_linkstatus|/etc/utopia/service.d/service_sshd.sh",
 #endif
                                         NULL 
                                       };

--- a/source/scripts/init/c_registration/15_ssh_server.c
+++ b/source/scripts/init/c_registration/15_ssh_server.c
@@ -47,6 +47,7 @@ const char* SERVICE_CUSTOM_EVENTS[] = {
                                         "bridge-status|/etc/utopia/service.d/service_sshd.sh",
 #ifdef WAN_FAILOVER_SUPPORTED					
 					"current_wan_ifname|/etc/utopia/service.d/service_sshd.sh",
+					"current_wan_ipaddr|/etc/utopia/service.d/service_sshd.sh",
 #endif					
 #if defined(_ARRIS_XB6_PRODUCT_REQ_)
                                         "wan-status|/etc/utopia/service.d/service_sshd.sh",

--- a/source/scripts/init/c_registration/15_ssh_server.c
+++ b/source/scripts/init/c_registration/15_ssh_server.c
@@ -47,6 +47,7 @@ const char* SERVICE_CUSTOM_EVENTS[] = {
                                         "bridge-status|/etc/utopia/service.d/service_sshd.sh",
 #ifdef WAN_FAILOVER_SUPPORTED					
 					"current_wan_ifname|/etc/utopia/service.d/service_sshd.sh",
+                                        "wan-status|/etc/utopia/service.d/service_sshd.sh",
 #endif					
 #if defined(_ARRIS_XB6_PRODUCT_REQ_)
                                         "wan-status|/etc/utopia/service.d/service_sshd.sh",

--- a/source/scripts/init/c_registration/15_ssh_server.c
+++ b/source/scripts/init/c_registration/15_ssh_server.c
@@ -51,6 +51,9 @@ const char* SERVICE_CUSTOM_EVENTS[] = {
 #if defined(_ARRIS_XB6_PRODUCT_REQ_)
                                         "wan-status|/etc/utopia/service.d/service_sshd.sh",
 #endif
+#if defined(_WNXL11BWL_PRODUCT_REQ_)
+                                        "remote_ssh_server_ip|/etc/utopia/service.d/service_sshd.sh",
+#endif
                                         NULL 
                                       };
 

--- a/source/scripts/init/c_registration/15_ssh_server.c
+++ b/source/scripts/init/c_registration/15_ssh_server.c
@@ -47,7 +47,6 @@ const char* SERVICE_CUSTOM_EVENTS[] = {
                                         "bridge-status|/etc/utopia/service.d/service_sshd.sh",
 #ifdef WAN_FAILOVER_SUPPORTED					
 					"current_wan_ifname|/etc/utopia/service.d/service_sshd.sh",
-					"current_wan_ipaddr|/etc/utopia/service.d/service_sshd.sh",
 #endif					
 #if defined(_ARRIS_XB6_PRODUCT_REQ_)
                                         "wan-status|/etc/utopia/service.d/service_sshd.sh",

--- a/source/scripts/init/c_registration/15_ssh_server.c
+++ b/source/scripts/init/c_registration/15_ssh_server.c
@@ -47,7 +47,6 @@ const char* SERVICE_CUSTOM_EVENTS[] = {
                                         "bridge-status|/etc/utopia/service.d/service_sshd.sh",
 #ifdef WAN_FAILOVER_SUPPORTED					
 					"current_wan_ifname|/etc/utopia/service.d/service_sshd.sh",
-                                        "wan-status|/etc/utopia/service.d/service_sshd.sh",
 #endif					
 #if defined(_ARRIS_XB6_PRODUCT_REQ_)
                                         "wan-status|/etc/utopia/service.d/service_sshd.sh",

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -213,8 +213,8 @@ do_start() {
             if [ ! -z "$CM_IP" ]; then
                 commandString="$commandString -p [$CM_IP]:22"
             else
-                echo_t "[utopia] $CMINTERFACE has no IP yet, will retry on remote_ssh_server_ip event"
-	    fi
+                echo_t "[utopia] $CMINTERFACE has no IP yet, will retry on mesh_wan_linkstatus event"
+            fi
             echo_t "[utopia] CM_IP $CM_IP "
         fi
 
@@ -449,10 +449,17 @@ case "$1" in
       service_stop
       service_start
       ;;
-  remote_ssh_server_ip)
+  mesh_wan_linkstatus)
       if [ "$BOX_TYPE" = "WNXL11BWL" ]; then
-          service_stop
-          service_start
+      echo_t "mesh_wan_linkstatus_value $2"
+      echo_t "mesh_wan_linkstatus_sysevent `sysevent get mesh_wan_linkstatus`"
+          if [ "$2" = "up" ]; then
+              DEVICE_MODE=`deviceinfo.sh -mode`
+              if [ "$DEVICE_MODE" = "Extender" ]; then
+                  service_stop
+                  service_start
+              fi
+          fi
       fi
       ;;
 

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -494,7 +494,7 @@ case "$1" in
       ;;
 
   *)
-        echo "Usage: $SELF_NAME [${SERVICE_NAME}-start|${SERVICE_NAME}-stop|${SERVICE_NAME}-restart|ssh_server_restart|lan-status|wan-status|mesh_wan_linkstatus]" >&2
+        echo "Usage: $SELF_NAME [${SERVICE_NAME}-start|${SERVICE_NAME}-stop|${SERVICE_NAME}-restart|wan-status|bridge-status|current_wan_ifname|mesh_wan_linkstatus <status>]" >&2
         exit 3
         ;;
 esac

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -142,9 +142,10 @@ wait_for_iface_ip() {
     local IFACE="$1"
     local SLEEP_INTERVAL=2
     local RETRIES=0
-    local MAX_RETRIES=150   # 150 x 2s = 300s max wait
+    local MAX_RETRIES=150
+    local WAITED_IP
     while [ $RETRIES -lt $MAX_RETRIES ]; do
-        WAITED_IP=`ip -4 addr show dev $IFACE scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
+        WAITED_IP=`ip -4 addr show dev "$IFACE" scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
         if [ -n "$WAITED_IP" ]; then
             echo_t "[utopia] $IFACE got IP $WAITED_IP after $(((RETRIES + 1) * SLEEP_INTERVAL)) seconds"
             echo "$WAITED_IP"
@@ -251,10 +252,7 @@ do_start() {
                     echo_t "[utopia] $CMINTERFACE has no IP and device is not in Extender mode, skipping wait"
                 fi
            fi
-            echo_t "[utopia] CM_IP $CM_IP "
         fi
-
-        echo_t "[utopia] commandString $commandString"
     else
         CM_IP=""
         if ([ "$BOX_TYPE" = "rpi" ] || [ "$BOX_TYPE" = "bpi" ]) ;then

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -134,36 +134,6 @@ get_listen_params() {
     fi
 }
 
-# wait_for_iface_ip <interface>
-# Polls every 2 seconds up to 120 seconds for an IPv4 address on the given
-# interface, then triggers a sshd restart.  Must be called in the background.
-# A lock file prevents multiple concurrent pollers from running.
-WAIT_FOR_IP_LOCKFILE="/tmp/.sshd_wait_for_ip.lock"
-wait_for_iface_ip() {
-    local IFACE="$1"
-    # Bail out if a poller is already running
-    if [ -f "$WAIT_FOR_IP_LOCKFILE" ]; then
-        echo_t "[utopia] wait_for_iface_ip already running for $IFACE, skipping"
-        return 1
-    fi
-    touch "$WAIT_FOR_IP_LOCKFILE"
-    local RETRIES=0
-    local MAX_RETRIES=60   # 60 x 2s = 120s max wait
-    while [ $RETRIES -lt $MAX_RETRIES ]; do
-        sleep 2
-        WAITED_IP=`ip -4 addr show dev $IFACE scope global | awk '/inet/{print $2}' | cut -d '/' -f1`
-        if [ -n "$WAITED_IP" ]; then
-            echo_t "[utopia] $IFACE got IP $WAITED_IP, restarting ${SERVICE_NAME}"
-            rm -f "$WAIT_FOR_IP_LOCKFILE"
-            /etc/utopia/service.d/service_sshd.sh ${SERVICE_NAME}-restart
-            return 0
-        fi
-        RETRIES=$((RETRIES + 1))
-    done
-    rm -f "$WAIT_FOR_IP_LOCKFILE"
-    echo_t "[utopia] Timed out waiting for IP on $IFACE after $((MAX_RETRIES * 2)) seconds"
-}
-
 do_start() {
    #DIR_NAME=/tmp/home/admin
    #if [ ! -d $DIR_NAME ] ; then
@@ -243,13 +213,7 @@ do_start() {
             if [ ! -z "$CM_IP" ]; then
                 commandString="$commandString -p [$CM_IP]:22"
             else
-                DEVICE_MODE=`deviceinfo.sh -mode`
-                if [ "$DEVICE_MODE" = "Extender" ]; then
-                    echo_t "[utopia] $CMINTERFACE has no IP yet (Extender mode), starting background wait for IP on $CMINTERFACE"
-                    wait_for_iface_ip "$CMINTERFACE" &
-                else
-                    echo_t "[utopia] $CMINTERFACE has no IP and device is not in Extender mode, skipping wait"
-                fi
+                echo_t "[utopia] $CMINTERFACE has no IP yet, will retry on remote_ssh_server_ip event"
 	    fi
             echo_t "[utopia] CM_IP $CM_IP "
         fi
@@ -484,6 +448,12 @@ case "$1" in
   current_wan_ifname)
       service_stop
       service_start
+      ;;
+  remote_ssh_server_ip)
+      if [ "$BOX_TYPE" = "WNXL11BWL" ]; then
+          service_stop
+          service_start
+      fi
       ;;
 
   *)

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -134,36 +134,6 @@ get_listen_params() {
     fi
 }
 
-# wait_for_iface_ip <interface>
-# Polls every 2 seconds up to 120 seconds for an IPv4 address on the given
-# interface, then triggers a sshd restart.  Must be called in the background.
-# A lock file prevents multiple concurrent pollers from running.
-WAIT_FOR_IP_LOCKFILE="/tmp/.sshd_wait_for_ip.lock"
-wait_for_iface_ip() {
-    local IFACE="$1"
-    # Bail out if a poller is already running
-    if [ -f "$WAIT_FOR_IP_LOCKFILE" ]; then
-        echo_t "[utopia] wait_for_iface_ip already running for $IFACE, skipping"
-        return 1
-    fi
-    touch "$WAIT_FOR_IP_LOCKFILE"
-    local RETRIES=0
-    local MAX_RETRIES=60   # 60 x 2s = 120s max wait
-    while [ $RETRIES -lt $MAX_RETRIES ]; do
-        sleep 2
-        WAITED_IP=`ip -4 addr show dev $IFACE scope global | awk '/inet/{print $2}' | cut -d '/' -f1`
-        if [ -n "$WAITED_IP" ]; then
-            echo_t "[utopia] $IFACE got IP $WAITED_IP, restarting ${SERVICE_NAME}"
-            rm -f "$WAIT_FOR_IP_LOCKFILE"
-            /etc/utopia/service.d/service_sshd.sh ${SERVICE_NAME}-restart
-            return 0
-        fi
-        RETRIES=$((RETRIES + 1))
-    done
-    rm -f "$WAIT_FOR_IP_LOCKFILE"
-    echo_t "[utopia] Timed out waiting for IP on $IFACE after $((MAX_RETRIES * 2)) seconds"
-}
-
 do_start() {
    #DIR_NAME=/tmp/home/admin
    #if [ ! -d $DIR_NAME ] ; then
@@ -232,14 +202,6 @@ do_start() {
 	    CM_IP=`ip -4 addr show dev $CMINTERFACE  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
         if [ ! -z $CM_IP ]; then
 	        commandString="$commandString -p [$CM_IP]:22"
-        else
-            DEVICE_MODE=`deviceinfo.sh -mode`
-            if [ "$DEVICE_MODE" = "Extender" ]; then
-                echo_t "[utopia] $CMINTERFACE has no IP yet (Extender mode), starting background wait for IP on $CMINTERFACE"
-                wait_for_iface_ip "$CMINTERFACE" &
-            else
-                echo_t "[utopia] $CMINTERFACE has no IP and device is not in Extender mode, skipping wait"
-            fi
 	    fi
         echo_t "[utopia] CM_IP $CM_IP "    
         CM_IPv6=`ip -6 addr show dev wwan0  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -200,18 +200,21 @@ do_start() {
         echo_t "[utopia] route `route -n`"
         echo_t "[utopia] CMINTERFACE $CMINTERFACE "
         echo_t "[utopia] current_wan_ipaddr `sysevent get current_wan_ipaddr`"
-	    CM_IP=`ip -4 addr show dev $CMINTERFACE  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
-        if [ ! -z $CM_IP ]; then
-	        commandString="$commandString -p [$CM_IP]:22"
-	    fi
-        echo_t "[utopia] CM_IP $CM_IP "    
+
         CM_IPv6=`ip -6 addr show dev wwan0  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
-	    if [ ! -z $CM_IPv6 ]; then
+	    if [ ! -z "$CM_IPv6" ]; then
             commandString="$commandString -p [$CM_IPv6]:22"
 	    fi
 	    CM_IPv4=`ip -4 addr show dev wwan0  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
-	    if [ ! -z $CM_IPv4 ]; then
+        if [ ! -z "$CM_IPv4" ]; then
             commandString="$commandString -p [$CM_IPv4]:22"
+        fi
+        if [ "$CMINTERFACE" != "wwan0" ]; then
+            CM_IP=`ip -4 addr show dev $CMINTERFACE  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
+            if [ ! -z "$CM_IP" ]; then
+                commandString="$commandString -p [$CM_IP]:22"
+            fi
+            echo_t "[utopia] CM_IP $CM_IP "
         fi
         echo_t "[utopia] commandString $commandString"
     else

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -199,7 +199,6 @@ do_start() {
         echo_t "[utopia] devicemode `deviceinfo.sh -mode`"
         echo_t "[utopia] route `route -n`"
         echo_t "[utopia] CMINTERFACE $CMINTERFACE "
-        echo_t "[utopia] current_wan_ipaddr `sysevent get current_wan_ipaddr`"
 
         CM_IPv6=`ip -6 addr show dev wwan0  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
 	    if [ ! -z "$CM_IPv6" ]; then
@@ -444,10 +443,6 @@ case "$1" in
       service_bridge_status
       ;;
   current_wan_ifname)
-      service_stop
-      service_start
-      ;;
-  current_wan_ipaddr)
       service_stop
       service_start
       ;;

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -462,7 +462,7 @@ case "$1" in
       #service_lanwan_status
       #;;
  wan-status)
-   if ([ "$BOX_TYPE" = "XB6" -a "$MANUFACTURE" = "Arris" ] || [ "$BOX_TYPE" = "WNXL11BWL" ]) ;then
+   if ([ "$BOX_TYPE" = "XB6" -a "$MANUFACTURE" = "Arris" ]) ;then
       echo_t "utopia: Need to handle the wan-status event."
       if [ -n "$CURRENT_WAN_STATUS" ]; then
         if [ "started" = "$CURRENT_WAN_STATUS" ]; then

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -134,6 +134,36 @@ get_listen_params() {
     fi
 }
 
+# wait_for_iface_ip <interface>
+# Polls every 2 seconds up to 120 seconds for an IPv4 address on the given
+# interface, then triggers a sshd restart.  Must be called in the background.
+# A lock file prevents multiple concurrent pollers from running.
+WAIT_FOR_IP_LOCKFILE="/tmp/.sshd_wait_for_ip.lock"
+wait_for_iface_ip() {
+    local IFACE="$1"
+    # Bail out if a poller is already running
+    if [ -f "$WAIT_FOR_IP_LOCKFILE" ]; then
+        echo_t "[utopia] wait_for_iface_ip already running for $IFACE, skipping"
+        return 1
+    fi
+    touch "$WAIT_FOR_IP_LOCKFILE"
+    local RETRIES=0
+    local MAX_RETRIES=60   # 60 x 2s = 120s max wait
+    while [ $RETRIES -lt $MAX_RETRIES ]; do
+        sleep 2
+        WAITED_IP=`ip -4 addr show dev $IFACE scope global | awk '/inet/{print $2}' | cut -d '/' -f1`
+        if [ -n "$WAITED_IP" ]; then
+            echo_t "[utopia] $IFACE got IP $WAITED_IP, restarting ${SERVICE_NAME}"
+            rm -f "$WAIT_FOR_IP_LOCKFILE"
+            /etc/utopia/service.d/service_sshd.sh ${SERVICE_NAME}-restart
+            return 0
+        fi
+        RETRIES=$((RETRIES + 1))
+    done
+    rm -f "$WAIT_FOR_IP_LOCKFILE"
+    echo_t "[utopia] Timed out waiting for IP on $IFACE after $((MAX_RETRIES * 2)) seconds"
+}
+
 do_start() {
    #DIR_NAME=/tmp/home/admin
    #if [ ! -d $DIR_NAME ] ; then
@@ -212,9 +242,18 @@ do_start() {
             CM_IP=`ip -4 addr show dev $CMINTERFACE  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
             if [ ! -z "$CM_IP" ]; then
                 commandString="$commandString -p [$CM_IP]:22"
-            fi
+            else
+                DEVICE_MODE=`deviceinfo.sh -mode`
+                if [ "$DEVICE_MODE" = "Extender" ]; then
+                    echo_t "[utopia] $CMINTERFACE has no IP yet (Extender mode), starting background wait for IP on $CMINTERFACE"
+                    wait_for_iface_ip "$CMINTERFACE" &
+                else
+                    echo_t "[utopia] $CMINTERFACE has no IP and device is not in Extender mode, skipping wait"
+                fi
+	    fi
             echo_t "[utopia] CM_IP $CM_IP "
         fi
+
         echo_t "[utopia] commandString $commandString"
     else
         CM_IP=""

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -147,14 +147,14 @@ wait_for_iface_ip() {
     while [ $RETRIES -lt $MAX_RETRIES ]; do
         WAITED_IP=`ip -4 addr show dev "$IFACE" scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
         if [ -n "$WAITED_IP" ]; then
-            echo_t "[utopia] $IFACE got IP $WAITED_IP after $(((RETRIES + 1) * SLEEP_INTERVAL)) seconds"
+            echo_t "[utopia] $IFACE got IP $WAITED_IP after $((RETRIES * SLEEP_INTERVAL)) seconds" >&2
             echo "$WAITED_IP"
             return 0
         fi
         RETRIES=$((RETRIES + 1))
         sleep $SLEEP_INTERVAL
     done
-    echo_t "[utopia] ERROR: Timed out waiting for IP on $IFACE after $((MAX_RETRIES * SLEEP_INTERVAL)) seconds"
+    echo_t "[utopia] ERROR: Timed out waiting for IP on $IFACE after $((MAX_RETRIES * SLEEP_INTERVAL)) seconds" >&2
     return 1
 }
 
@@ -220,7 +220,7 @@ do_start() {
 	    fi
         fi
     elif [ "$BOX_TYPE" = "WNXL11BWL" ]; then
-
+        commandString=""
         CM_IPv6=`ip -6 addr show dev wwan0  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
 	    if [ ! -z "$CM_IPv6" ]; then
             commandString="$commandString -p [$CM_IPv6]:22"
@@ -230,7 +230,7 @@ do_start() {
             commandString="$commandString -p [$CM_IPv4]:22"
         fi
         if [ "$CMINTERFACE" != "wwan0" ]; then
-            CM_IP=`ip -4 addr show dev $CMINTERFACE  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
+            CM_IP=`ip -4 addr show dev "$CMINTERFACE"  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
             if [ ! -z "$CM_IP" ]; then
                 commandString="$commandString -p [$CM_IP]:22"
             else

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -144,7 +144,6 @@ wait_for_iface_ip() {
     local RETRIES=0
     local MAX_RETRIES=150   # 150 x 2s = 300s max wait
     while [ $RETRIES -lt $MAX_RETRIES ]; do
-        sleep $SLEEP_INTERVAL
         WAITED_IP=`ip -4 addr show dev $IFACE scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
         if [ -n "$WAITED_IP" ]; then
             echo_t "[utopia] $IFACE got IP $WAITED_IP after $(((RETRIES + 1) * SLEEP_INTERVAL)) seconds"
@@ -152,6 +151,7 @@ wait_for_iface_ip() {
             return 0
         fi
         RETRIES=$((RETRIES + 1))
+        sleep $SLEEP_INTERVAL
     done
     echo_t "[utopia] ERROR: Timed out waiting for IP on $IFACE after $((MAX_RETRIES * SLEEP_INTERVAL)) seconds"
     return 1
@@ -486,15 +486,11 @@ case "$1" in
       service_start
       ;;
   mesh_wan_linkstatus)
-      if [ "$BOX_TYPE" = "WNXL11BWL" ]; then
-      echo_t "mesh_wan_linkstatus_value $2"
-      echo_t "mesh_wan_linkstatus_sysevent `sysevent get mesh_wan_linkstatus`"
-          if [ "$2" = "up" ]; then
-              DEVICE_MODE=`deviceinfo.sh -mode`
-              if [ "$DEVICE_MODE" = "Extender" ]; then
-                  service_stop
-                  service_start
-              fi
+      if [ "$BOX_TYPE" = "WNXL11BWL" ] && [ "$2" = "up" ]; then
+          DEVICE_MODE=`deviceinfo.sh -mode`
+          if [ "$DEVICE_MODE" = "Extender" ]; then
+              service_stop
+              service_start
           fi
       fi
       ;;

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -145,9 +145,9 @@ wait_for_iface_ip() {
     local MAX_RETRIES=150   # 150 x 2s = 300s max wait
     while [ $RETRIES -lt $MAX_RETRIES ]; do
         sleep $SLEEP_INTERVAL
-        WAITED_IP=`ip -4 addr show dev $IFACE scope global | awk '/inet/{print $2}' | cut -d '/' -f1`
+        WAITED_IP=`ip -4 addr show dev $IFACE scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
         if [ -n "$WAITED_IP" ]; then
-            echo_t "[utopia] $IFACE got IP $WAITED_IP after $((RETRIES * SLEEP_INTERVAL)) seconds"
+            echo_t "[utopia] $IFACE got IP $WAITED_IP after $(((RETRIES + 1) * SLEEP_INTERVAL)) seconds"
             echo "$WAITED_IP"
             return 0
         fi
@@ -219,9 +219,6 @@ do_start() {
 	    fi
         fi
     elif [ "$BOX_TYPE" = "WNXL11BWL" ]; then
-        echo_t "[utopia] devicemode `deviceinfo.sh -mode`"
-        echo_t "[utopia] route `route -n`"
-        echo_t "[utopia] CMINTERFACE $CMINTERFACE "
 
         CM_IPv6=`ip -6 addr show dev wwan0  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
 	    if [ ! -z "$CM_IPv6" ]; then
@@ -503,7 +500,7 @@ case "$1" in
       ;;
 
   *)
-        echo "Usage: $SELF_NAME [${SERVICE_NAME}-start|${SERVICE_NAME}-stop|${SERVICE_NAME}-restart|ssh_server_restart|lan-status|wan-status]" >&2
+        echo "Usage: $SELF_NAME [${SERVICE_NAME}-start|${SERVICE_NAME}-stop|${SERVICE_NAME}-restart|ssh_server_restart|lan-status|wan-status|mesh_wan_linkstatus]" >&2
         exit 3
         ;;
 esac

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -196,10 +196,14 @@ do_start() {
 	    fi
         fi
     elif [ "$BOX_TYPE" = "WNXL11BWL" ]; then
+        echo_t "[utopia] devicemode `deviceinfo.sh -mode`"
+        echo_t "[utopia] route `route -n`"
+        echo_t "[utopia] CMINTERFACE $CMINTERFACE "
 	    CM_IP=`ip -4 addr show dev $CMINTERFACE  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
         if [ ! -z $CM_IP ]; then
 	        commandString="$commandString -p [$CM_IP]:22"
 	    fi
+        echo_t "[utopia] CM_IP $CM_IP "    
         CM_IPv6=`ip -6 addr show dev wwan0  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
 	    if [ ! -z $CM_IPv6 ]; then
             commandString="$commandString -p [$CM_IPv6]:22"
@@ -208,6 +212,7 @@ do_start() {
 	    if [ ! -z $CM_IPv4 ]; then
             commandString="$commandString -p [$CM_IPv4]:22"
         fi
+        echo_t "[utopia] commandString $commandString"
     else
         CM_IP=""
         if ([ "$BOX_TYPE" = "rpi" ] || [ "$BOX_TYPE" = "bpi" ]) ;then

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -424,7 +424,7 @@ case "$1" in
       #service_lanwan_status
       #;;
  wan-status)
-   if ([ "$BOX_TYPE" = "XB6" -a "$MANUFACTURE" = "Arris" ]) ;then
+   if ([ "$BOX_TYPE" = "XB6" -a "$MANUFACTURE" = "Arris" ] || [ "$BOX_TYPE" = "WNXL11BWL" ]) ;then
       echo_t "utopia: Need to handle the wan-status event."
       if [ -n "$CURRENT_WAN_STATUS" ]; then
         if [ "started" = "$CURRENT_WAN_STATUS" ]; then

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -134,6 +134,29 @@ get_listen_params() {
     fi
 }
 
+# wait_for_iface_ip <interface>
+# Blocks up to 300 seconds (150 x 2s) waiting for an IPv4 address on the
+# given interface.  Prints the IP to stdout on success; logs an error and
+# returns 1 on timeout.
+wait_for_iface_ip() {
+    local IFACE="$1"
+    local SLEEP_INTERVAL=2
+    local RETRIES=0
+    local MAX_RETRIES=150   # 150 x 2s = 300s max wait
+    while [ $RETRIES -lt $MAX_RETRIES ]; do
+        sleep $SLEEP_INTERVAL
+        WAITED_IP=`ip -4 addr show dev $IFACE scope global | awk '/inet/{print $2}' | cut -d '/' -f1`
+        if [ -n "$WAITED_IP" ]; then
+            echo_t "[utopia] $IFACE got IP $WAITED_IP after $((RETRIES * SLEEP_INTERVAL)) seconds"
+            echo "$WAITED_IP"
+            return 0
+        fi
+        RETRIES=$((RETRIES + 1))
+    done
+    echo_t "[utopia] ERROR: Timed out waiting for IP on $IFACE after $((MAX_RETRIES * SLEEP_INTERVAL)) seconds"
+    return 1
+}
+
 do_start() {
    #DIR_NAME=/tmp/home/admin
    #if [ ! -d $DIR_NAME ] ; then
@@ -213,8 +236,24 @@ do_start() {
             if [ ! -z "$CM_IP" ]; then
                 commandString="$commandString -p [$CM_IP]:22"
             else
-                echo_t "[utopia] $CMINTERFACE has no IP yet, will retry on mesh_wan_linkstatus event"
-            fi
+                DEVICE_MODE=`deviceinfo.sh -mode`
+                if [ "$DEVICE_MODE" = "Extender" ]; then
+                    MESH_WAN_STATUS=`sysevent get mesh_wan_linkstatus`
+                    if [ "$MESH_WAN_STATUS" = "up" ]; then
+                        echo_t "[utopia] $CMINTERFACE has no IP (Extender mode, mesh WAN up), waiting up to 300s"
+                        CM_IP=`wait_for_iface_ip "$CMINTERFACE"`
+                        if [ -n "$CM_IP" ]; then
+                            commandString="$commandString -p [$CM_IP]:22"
+                        else
+                            echo_t "[utopia] ERROR: $CMINTERFACE did not get an IP after 300s, dropbear will start without it"
+                        fi
+                    else
+                        echo_t "[utopia] $CMINTERFACE has no IP and mesh_wan_linkstatus is not up, skipping wait"
+                    fi
+                else
+                    echo_t "[utopia] $CMINTERFACE has no IP and device is not in Extender mode, skipping wait"
+                fi
+           fi
             echo_t "[utopia] CM_IP $CM_IP "
         fi
 

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -134,6 +134,36 @@ get_listen_params() {
     fi
 }
 
+# wait_for_iface_ip <interface>
+# Polls every 2 seconds up to 120 seconds for an IPv4 address on the given
+# interface, then triggers a sshd restart.  Must be called in the background.
+# A lock file prevents multiple concurrent pollers from running.
+WAIT_FOR_IP_LOCKFILE="/tmp/.sshd_wait_for_ip.lock"
+wait_for_iface_ip() {
+    local IFACE="$1"
+    # Bail out if a poller is already running
+    if [ -f "$WAIT_FOR_IP_LOCKFILE" ]; then
+        echo_t "[utopia] wait_for_iface_ip already running for $IFACE, skipping"
+        return 1
+    fi
+    touch "$WAIT_FOR_IP_LOCKFILE"
+    local RETRIES=0
+    local MAX_RETRIES=60   # 60 x 2s = 120s max wait
+    while [ $RETRIES -lt $MAX_RETRIES ]; do
+        sleep 2
+        WAITED_IP=`ip -4 addr show dev $IFACE scope global | awk '/inet/{print $2}' | cut -d '/' -f1`
+        if [ -n "$WAITED_IP" ]; then
+            echo_t "[utopia] $IFACE got IP $WAITED_IP, restarting ${SERVICE_NAME}"
+            rm -f "$WAIT_FOR_IP_LOCKFILE"
+            /etc/utopia/service.d/service_sshd.sh ${SERVICE_NAME}-restart
+            return 0
+        fi
+        RETRIES=$((RETRIES + 1))
+    done
+    rm -f "$WAIT_FOR_IP_LOCKFILE"
+    echo_t "[utopia] Timed out waiting for IP on $IFACE after $((MAX_RETRIES * 2)) seconds"
+}
+
 do_start() {
    #DIR_NAME=/tmp/home/admin
    #if [ ! -d $DIR_NAME ] ; then
@@ -202,6 +232,14 @@ do_start() {
 	    CM_IP=`ip -4 addr show dev $CMINTERFACE  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
         if [ ! -z $CM_IP ]; then
 	        commandString="$commandString -p [$CM_IP]:22"
+        else
+            DEVICE_MODE=`deviceinfo.sh -mode`
+            if [ "$DEVICE_MODE" = "Extender" ]; then
+                echo_t "[utopia] $CMINTERFACE has no IP yet (Extender mode), starting background wait for IP on $CMINTERFACE"
+                wait_for_iface_ip "$CMINTERFACE" &
+            else
+                echo_t "[utopia] $CMINTERFACE has no IP and device is not in Extender mode, skipping wait"
+            fi
 	    fi
         echo_t "[utopia] CM_IP $CM_IP "    
         CM_IPv6=`ip -6 addr show dev wwan0  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`

--- a/source/scripts/init/service.d/service_sshd.sh
+++ b/source/scripts/init/service.d/service_sshd.sh
@@ -199,6 +199,7 @@ do_start() {
         echo_t "[utopia] devicemode `deviceinfo.sh -mode`"
         echo_t "[utopia] route `route -n`"
         echo_t "[utopia] CMINTERFACE $CMINTERFACE "
+        echo_t "[utopia] current_wan_ipaddr `sysevent get current_wan_ipaddr`"
 	    CM_IP=`ip -4 addr show dev $CMINTERFACE  scope global | awk '/inet/{print $2}' | cut -d '/' -f1 | head -n1`
         if [ ! -z $CM_IP ]; then
 	        commandString="$commandString -p [$CM_IP]:22"
@@ -440,6 +441,10 @@ case "$1" in
       service_bridge_status
       ;;
   current_wan_ifname)
+      service_stop
+      service_start
+      ;;
+  current_wan_ipaddr)
       service_stop
       service_start
       ;;


### PR DESCRIPTION
Reason for change: In XLE, after Gateway Restore, dropbear is not listening on `br-home` interface. To address this, we know listen to `mesh_wan_linkstatus` sysevent, and also have a retry mechanism via `wait_for_iface_ip`
Test Procedure: Check if XLE is SSH-able after Gateway Restore
Priority: P1