### PR TITLE
XER10-2920 To bring the apply_system_defaults_psm in xer10-sky-uk

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,7 +105,7 @@ if test x"${MACHINE}" != x; then
                      [The machine type])
 fi
 
-AM_CONDITIONAL([MACHINE_SCXER10], [test "x$MACHINE" = "xscxer10" || test "x$MACHINE" = "xscxer10-sdk6.3"])
+AM_CONDITIONAL([MACHINE_SCXER10], [echo "$MACHINE" | grep -q "scxer10"])
 
 AM_CONDITIONAL([MULTILAN_FEATURE], [test "$MULTILAN_FEATURE" = "yes"])
 AM_CONDITIONAL([CPC_FIREWALL_ENABLE], [test "x$CPC_FIREWALL_ENABLE" = "xtrue"])

--- a/configure.ac
+++ b/configure.ac
@@ -105,7 +105,7 @@ if test x"${MACHINE}" != x; then
                      [The machine type])
 fi
 
-AM_CONDITIONAL([MACHINE_SCXER10], [test "x$MACHINE" = "xscxer10"])
+AM_CONDITIONAL([MACHINE_SCXER10], [test "x$MACHINE" = "xscxer10" || test "x$MACHINE" = "xscxer10-sdk6.3"])
 
 AM_CONDITIONAL([MULTILAN_FEATURE], [test "$MULTILAN_FEATURE" = "yes"])
 AM_CONDITIONAL([CPC_FIREWALL_ENABLE], [test "x$CPC_FIREWALL_ENABLE" = "xtrue"])


### PR DESCRIPTION
To bring the /usr/bin/apply_system_defaults_psm in xer10-sky-uk. Adding xer10-sdk6.3 machine in configure.ac file