### PR TITLE
RDKB-64798: Default xconf URL using Autoexcluded.xconf value

### DIFF
--- a/source/scripts/init/defaults/system_defaults_arm
+++ b/source/scripts/init/defaults/system_defaults_arm
@@ -1392,7 +1392,7 @@ $ddns_server_retryinterval_5=660
 
 #Control firmware update exclusion
 $AutoExcludedEnabled=false
-$AutoExcludedURL=https://xconf.xcal.tv/xconf/swu/stb
+$AutoExcludedURL=https://xconf.xcal.tv/xconf/firmware/stb
 
 #HWSelfTest Enable(Default =false)
 $hwHealthTest=false

--- a/source/scripts/init/defaults/system_defaults_bci
+++ b/source/scripts/init/defaults/system_defaults_bci
@@ -1271,7 +1271,7 @@ $ddns_server_retryinterval_5=660
 
 #Control firmware update exclusion
 $AutoExcludedEnabled=false
-$AutoExcludedURL=https://xconf.xcal.tv/xconf/swu/stb
+$AutoExcludedURL=https://xconf.xcal.tv/xconf/firmware/stb
 
 #HWSelfTest Enable(Default =false)
 $hwHealthTest=false

--- a/source/scripts/init/defaults/system_defaults_xd4
+++ b/source/scripts/init/defaults/system_defaults_xd4
@@ -1371,7 +1371,7 @@ $ddns_server_retryinterval_5=660
 
 #Control firmware update exclusion
 $AutoExcludedEnabled=false
-$AutoExcludedURL=https://xconf.xcal.tv/xconf/swu/stb
+$AutoExcludedURL=https://xconf.xcal.tv/xconf/firmware/stb
 
 #HWSelfTest Enable(Default =false)
 $hwHealthTest=false


### PR DESCRIPTION
Reason for change: Setting AutoExclude Xconf URL with CDN URL
Test Procedure: As mentioned in the ticket
Risk: Medium
Priority: P1