### PR TITLE
RDKCOM-5593: RDKBDEV-3446 IPQ Bug Fixes for QCOM

### DIFF
--- a/source/scripts/init/src/apply_system_defaults/apply_system_defaults.c
+++ b/source/scripts/init/src/apply_system_defaults/apply_system_defaults.c
@@ -929,7 +929,7 @@ static int get_PartnerID (char *PartnerID)
 
 #if defined (_XB6_PRODUCT_REQ_)
                 sprintf( PartnerID, "%s", "unknown" );
-#elif defined (_RDK_REF_PLATFORM_)
+#elif defined (_RDK_REF_PLATFORM_) || defined (_COSA_QCA_ARM_)
                 sprintf( PartnerID, "%s", "RDKM");
 #elif defined (_SR300_PRODUCT_REQ_) /* Default fall back option for ADA devices SKYH4-4946 */
                 sprintf( PartnerID, "%s", "sky-uk");
@@ -2404,6 +2404,7 @@ static int apply_partnerId_default_values (char *data, char *PartnerID)
     cJSON   *alwaysParamObjVal = NULL;
     char    *error_ptr         = NULL;
     int     iterator           = 0;
+    char    buf[50]            = {0};
 
 	/*
 	  * Case 1:
@@ -2534,8 +2535,9 @@ static int apply_partnerId_default_values (char *data, char *PartnerID)
                                         if ( paramObjVal != NULL )
                                         {
 						defaultAdminIP = paramObjVal->valuestring; 
+						syscfg_get( NULL, "lan_ipaddr", buf, sizeof( buf ));
 					
-						if (defaultAdminIP != NULL) 
+						if ((defaultAdminIP != NULL) && (strcmp(buf, defaultAdminIP) == 0))
 						{
 							set_syscfg_partner_values(defaultAdminIP,"lan_ipaddr");
 							defaultAdminIP = NULL;
@@ -2550,8 +2552,9 @@ static int apply_partnerId_default_values (char *data, char *PartnerID)
                                         if ( paramObjVal != NULL )
                                         {
 						subnetRange = paramObjVal->valuestring; 
+						syscfg_get( NULL, "lan_netmask", buf, sizeof( buf ));
 					
-						if (subnetRange != NULL) 
+						if ((subnetRange != NULL) && (strcmp(buf, subnetRange) == 0))
 						{
 							set_syscfg_partner_values(subnetRange,"lan_netmask");
 							subnetRange = NULL;
@@ -2565,8 +2568,9 @@ static int apply_partnerId_default_values (char *data, char *PartnerID)
                                         if ( paramObjVal != NULL )
                                         {
 						minAddress = paramObjVal->valuestring;
+						syscfg_get( NULL, "dhcp_start", buf, sizeof( buf ));
 
-						if (minAddress != NULL)
+						if ((minAddress != NULL) && (strcmp(buf, minAddress) ==0))
 						{
 							set_syscfg_partner_values(minAddress,"dhcp_start");
 							minAddress = NULL;
@@ -2580,8 +2584,9 @@ static int apply_partnerId_default_values (char *data, char *PartnerID)
                                         if ( paramObjVal != NULL )
                                         {
                                                 maxAddress = paramObjVal->valuestring;
+						syscfg_get( NULL, "dhcp_end", buf, sizeof( buf ));
 
-                                                if (maxAddress != NULL)
+                                                if ((maxAddress != NULL) && (strcmp(buf, maxAddress) == 0))
                                                 {
                                                         set_syscfg_partner_values(maxAddress,"dhcp_end");
                                                         maxAddress = NULL;

--- a/source/util/utils/util.c
+++ b/source/util/utils/util.c
@@ -66,7 +66,9 @@ int vsystem(const char *fmt, ...)
     if (n < 0 || n >= sizeof(cmd))
         return -1;
 
+    #ifndef _COSA_QCA_ARM_
     fprintf(stderr, "%s: %s\n", __FUNCTION__, cmd);
+    #endif
     return system(cmd);
 }
 


### PR DESCRIPTION
RDKBDEV-3446: IPQ Bug Fixes for QCOM Platform
Reason for change: 
- Captive portal functionality was not working correctly on IPQ devices. 
- Excessive logging was observed on IPQ devices. Logging has been reduced

Test Procedure: Flash the image with fix and test the captive portal functionality in IPQ
    Risks: Low
