### PR TITLE
RDKB-65464 : mesh_status.sh script should run evey 2 hours

### DIFF
--- a/source/scripts/init/service.d/service_crond.sh
+++ b/source/scripts/init/service.d/service_crond.sh
@@ -96,9 +96,9 @@ service_start ()
       if [ "$MOCA_SUPPORTED" != "false" ]; then
           echo "1 */12 * * *  /usr/ccsp/pam/moca_status.sh" >> $CRONTAB_FILE
       fi
-#RDKB-17984: Runs every 12 hours and prints mesh status
+#RDKB-17984: Runs every 2 hours and prints mesh status
       if [ "$BOX_TYPE" != "XB3" ]; then
-       echo "1 */12 * * *  /usr/ccsp/wifi/mesh_status.sh" >> $CRONTAB_FILE
+       echo "1 */2 * * *  /usr/ccsp/wifi/mesh_status.sh" >> $CRONTAB_FILE
       fi
 
       if [ "$BOX_TYPE" == "XB3" ]; then


### PR DESCRIPTION
Reason for change: mesh_status.sh script currently running 12 hours is giving wrong telemetry marker for connected pod details
Test Procedure: Check meshAgent log
Risks: Low
Priority: P1