### PR TITLE
RDKB-65527: High logupload happening on XB10 devices

### DIFF
--- a/source/scripts/init/defaults/system_defaults_arm
+++ b/source/scripts/init/defaults/system_defaults_arm
@@ -1368,9 +1368,6 @@ $EnableOCSPCA=true
 $XHFW_Enable=true
 $XHFW_Status="not activated"
 
-#Use XPKI certificate for lnf
-$LnFUseXPKI_Enable=true
-
 # Dynamic DNS
 $dynamic_dns_enable=0
 $ddns_service_providers_list=no-ip,dyndns,duckdns,afraid,easydns,changeip

--- a/source/scripts/init/defaults/system_defaults_bci
+++ b/source/scripts/init/defaults/system_defaults_bci
@@ -1255,9 +1255,6 @@ $low_queue_reboot_threshold=0
 $EnableOCSPStapling=true
 $EnableOCSPCA=true
 
-#Use XPKI certificate for lnf
-$LnFUseXPKI_Enable=true
-
 # Dynamic DNS
 $dynamic_dns_enable=0
 $ddns_service_providers_list=no-ip,dyndns,duckdns,afraid,easydns,changeip

--- a/source/scripts/init/defaults/system_defaults_xd4
+++ b/source/scripts/init/defaults/system_defaults_xd4
@@ -1347,9 +1347,6 @@ $EnableOCSPCA=true
 $XHFW_Enable=true
 $XHFW_Status="not activated"
 
-#Use XPKI certificate for lnf
-$LnFUseXPKI_Enable=true
-
 # Dynamic DNS
 $dynamic_dns_enable=0
 $ddns_service_providers_list=no-ip,dyndns,duckdns,afraid,easydns,changeip


### PR DESCRIPTION
Reason for change: Removed LNF value from defaults as it is not used in code
Test Procedure: As mentioned in the ticket
Risks: Medium
Priority: P1